### PR TITLE
Update xgboost_abalone.ipynb

### DIFF
--- a/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
@@ -58,7 +58,7 @@
     "region = boto3.Session().region_name\n",
     "\n",
     "bucket='<bucket-name>' # put your s3 bucket name here, and create s3 bucket\n",
-    "prefix = 'sagemarker/xgboost-regression'\n",
+    "prefix = 'sagemaker/xgboost-regression'\n",
     "# customize to your bucket where you have stored the data\n",
     "bucket_path = 'https://s3-{}.amazonaws.com/{}'.format(region,bucket)"
    ]


### PR DESCRIPTION
Fixed spelling error of S3 bucket prefix. Was sagemarker, changed to sagemaker.