### PR TITLE
Added explicit feature pairs in explanation for feature correlation

### DIFF
--- a/introduction_to_applying_machine_learning/xgboost_customer_churn/xgboost_customer_churn.ipynb
+++ b/introduction_to_applying_machine_learning/xgboost_customer_churn/xgboost_customer_churn.ipynb
@@ -243,7 +243,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We see several features that essentially have 100% correlation with one another.  Including these feature pairs in some machine learning algorithms can create catastrophic problems, while in others it will only introduce minor redundancy and bias.  Let's remove them anyway."
+    "We see several features that essentially have 100% correlation with one another.  Including these feature pairs in some machine learning algorithms can create catastrophic problems, while in others it will only introduce minor redundancy and bias.  Let's remove one of the feature in each highly correlated pairs: Day Charge from the pair with Day Mins, Night Charge from the pair with Night Mins, Intl Charge from the pair with Intl Mins:"
    ]
   },
   {

--- a/introduction_to_applying_machine_learning/xgboost_customer_churn/xgboost_customer_churn.ipynb
+++ b/introduction_to_applying_machine_learning/xgboost_customer_churn/xgboost_customer_churn.ipynb
@@ -243,7 +243,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We see several features that essentially have 100% correlation with one another.  Including these feature pairs in some machine learning algorithms can create catastrophic problems, while in others it will only introduce minor redundancy and bias.  Let's remove one of the feature in each highly correlated pairs: Day Charge from the pair with Day Mins, Night Charge from the pair with Night Mins, Intl Charge from the pair with Intl Mins:"
+    "We see several features that essentially have 100% correlation with one another.  Including these feature pairs in some machine learning algorithms can create catastrophic problems, while in others it will only introduce minor redundancy and bias.  Let's remove one feature from each of the highly correlated pairs: Day Charge from the pair with Day Mins, Night Charge from the pair with Night Mins, Intl Charge from the pair with Intl Mins:"
    ]
   },
   {


### PR DESCRIPTION
Explicit text about columns we are dropping due to high feature correlation. This makes it easier for the reader to follow why we are dropping the features 'Day Charge', 'Eve Charge', 'Night Charge', 'Intl Charge', which was confusing if you didn't notice the feature pairs.