### PR TITLE
remove num_class hyperparameter

### DIFF
--- a/introduction_to_applying_machine_learning/xgboost_direct_marketing/xgboost_direct_marketing_sagemaker.ipynb
+++ b/introduction_to_applying_machine_learning/xgboost_direct_marketing/xgboost_direct_marketing_sagemaker.ipynb
@@ -460,7 +460,6 @@
     "                        subsample=0.8,\n",
     "                        silent=0,\n",
     "                        objective='binary:logistic',\n",
-    "                        num_class=1, \n",
     "                        num_round=100)\n",
     "\n",
     "xgb.fit({'train': s3_input_train, 'validation': s3_input_validation}) "


### PR DESCRIPTION
num_class=1 gives error for binary classifcation task on sagemaker. Training does not complete. Removing it runs the training job successfully.