### PR TITLE
Fixed: unnecessary num_class hyperparameter in XGBoost Customer Churn

### DIFF
--- a/introduction_to_applying_machine_learning/xgboost_customer_churn/xgboost_customer_churn.ipynb
+++ b/introduction_to_applying_machine_learning/xgboost_customer_churn/xgboost_customer_churn.ipynb
@@ -397,7 +397,6 @@
     "                        subsample=0.8,\n",
     "                        silent=0,\n",
     "                        objective='binary:logistic',\n",
-    "                        num_class=1, \n",
     "                        num_round=100)\n",
     "\n",
     "xgb.fit({'train': s3_input_train, 'validation': s3_input_validation}) "


### PR DESCRIPTION
Tested this and it works in a SageMaker Notebook Instance.