### PR TITLE
remove num_class = 1

### DIFF
--- a/introduction_to_applying_machine_learning/video_game_sales/video-game-sales-xgboost.ipynb
+++ b/introduction_to_applying_machine_learning/video_game_sales/video-game-sales-xgboost.ipynb
@@ -393,7 +393,6 @@
     "        \"scale_pos_weight\":\"2.0\",\n",
     "        \"subsample\":\"0.5\",\n",
     "        \"objective\":\"binary:logistic\",\n",
-    "        \"num_class\":\"1\", \n",
     "        \"num_round\":\"100\"\n",
     "    },\n",
     "    \"StoppingCondition\": {\n",


### PR DESCRIPTION
line caused this error: 
"Failure reason
ClientError: Do not need to setup parameter 'num_class' for learning task other than multi classification."

Removing it allowed the job to finish.