### PR TITLE
fix parsing of string to List for single-line test's label

### DIFF
--- a/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
@@ -462,7 +462,7 @@
     "result = result.decode(\"utf-8\")\n",
     "result = result.split(',')\n",
     "result = [math.ceil(float(i)) for i in result]\n",
-    "label = payload.strip(' ')[0]\n",
+    "label = payload.strip(' ').split()[0]\n",
     "print ('Label: ',label,'\\nPrediction: ', result[0])"
    ]
   },


### PR DESCRIPTION
Currently the label for a 2-digit value is incorrectly parsed to a single character.  This error was not repeated for the larger validation run.