### PR TITLE
Added markdown on compatibility with sparkML

### DIFF
--- a/advanced_functionality/xgboost_bring_your_own_model/xgboost_bring_your_own_model.ipynb
+++ b/advanced_functionality/xgboost_bring_your_own_model/xgboost_bring_your_own_model.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "Amazon SageMaker includes functionality to support a hosted notebook environment, distributed, serverless training, and real-time hosting. We think it works best when all three of these services are used together, but they can also be used independently.  Some use cases may only require hosting.  Maybe the model was trained prior to Amazon SageMaker existing, in a different service.\n",
     "\n",
-    "This notebook shows how to use a pre-existing scikit-learn model with the Amazon SageMaker XGBoost Algorithm container to quickly create a hosted endpoint for that model.\n",
+    "This notebook shows how to use a pre-existing scikit-learn trained XGBoost model with the Amazon SageMaker XGBoost Algorithm container to quickly create a hosted endpoint for that model. Please note that scikit-learn XGBoost model is compatible with SageMaker XGBoost container, whereas other gradient boosted tree models (such as one trained in SparkML) are not.\n",
     "\n",
     "---\n",
     "## Setup\n",


### PR DESCRIPTION
Updated Markdown to callout that sparkML gradient boosted trees are not compatible with the SageMaker algorithm container.