### PR TITLE
Fixed: XGBoost Customer Churn dataset link

### DIFF
--- a/introduction_to_applying_machine_learning/xgboost_customer_churn/xgboost_customer_churn.ipynb
+++ b/introduction_to_applying_machine_learning/xgboost_customer_churn/xgboost_customer_churn.ipynb
@@ -111,7 +111,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget http://www.dataminingconsultant.com/data/churn.txt"
+    "!wget http://dataminingconsultant.com/DKD2e_data_sets.zip\n",
+    "!unzip -o DKD2e_data_sets.zip"
    ]
   },
   {
@@ -120,7 +121,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "churn = pd.read_csv('churn.txt')\n",
+    "churn = pd.read_csv('./Data sets/churn.txt')\n",
     "pd.set_option('display.max_columns', 500)\n",
     "churn"
    ]


### PR DESCRIPTION
Tested fix in ml.m4.xlarge SageMaker Notebook Instance and it passed.