### PR TITLE
Fixed: Moved to previous version of r-essentials.  Old version broke …

### DIFF
--- a/advanced_functionality/install_r_kernel/install_r_kernel.ipynb
+++ b/advanced_functionality/install_r_kernel/install_r_kernel.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!conda install --yes --name JupyterSystemEnv --channel r r-essentials"
+    "!conda install --yes --name JupyterSystemEnv --channel r r-essentials=1.6.0"
    ]
   },
   {


### PR DESCRIPTION
…the instance.

Related to this [issue](https://github.com/awslabs/amazon-sagemaker-examples/issues/204).