### PR TITLE
Update eval frequency param for TensorBoard notebook for TensorFlow 1.6

### DIFF
--- a/sagemaker-python-sdk/tensorflow_resnet_cifar10_with_tensorboard/tensorflow_resnet_cifar10_with_tensorboard.ipynb
+++ b/sagemaker-python-sdk/tensorflow_resnet_cifar10_with_tensorboard/tensorflow_resnet_cifar10_with_tensorboard.ipynb
@@ -51,6 +51,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -105,6 +106,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -116,7 +118,7 @@
     "estimator = TensorFlow(entry_point='resnet_cifar_10.py',\n",
     "                       source_dir=source_dir,\n",
     "                       role=role,\n",
-    "                       hyperparameters={'min_eval_frequency': 10},\n",
+    "                       hyperparameters={'throttle_secs': 30},\n",
     "                       training_steps=1000, evaluation_steps=100,\n",
     "                       train_instance_count=2, train_instance_type='ml.c4.xlarge', \n",
     "                       base_job_name='tensorboard-example')\n",
@@ -138,7 +140,7 @@
     "\n",
     "It takes a few minutes to provision containers and start the training job.**TensorBoard** will start to display metrics shortly after that.\n",
     "\n",
-    "You can access **TensorBoard** locally at [http://localhost:6006](http://localhost:6006) or using your SageMaker notebook instance [proxy/6006/](/proxy/6006/)(TensorBoard will not work if forget to put the slash, '/', in end of the url). If TensorBoard started on a different port, adjust these URLs to match.This example uses the optional hyperparameter **```min_eval_frequency```** to generate training evaluations more often, allowing to visualize **TensorBoard** scalar data faster. You can find the available optional hyperparameters [here](https://github.com/aws/sagemaker-python-sdk#optional-hyperparameters)**."
+    "You can access **TensorBoard** locally at [http://localhost:6006](http://localhost:6006) or using your SageMaker notebook instance [proxy/6006/](/proxy/6006/)(TensorBoard will not work if forget to put the slash, '/', in end of the url). If TensorBoard started on a different port, adjust these URLs to match.This example uses the optional hyperparameter **```throttle_secs```** to generate training evaluations more often, allowing to visualize **TensorBoard** scalar data faster. You can find the available optional hyperparameters [here](https://github.com/aws/sagemaker-python-sdk#optional-hyperparameters)."
    ]
   },
   {
@@ -155,7 +157,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "predictor = estimator.deploy(initial_instance_count=1, instance_type='ml.m4.xlarge')"
@@ -173,7 +177,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",


### PR DESCRIPTION
This change is documented here: https://github.com/aws/sagemaker-python-sdk/pull/124

Made this change by doing git clone on a Notebook Instance, then editing just the hyperparameter dict. Ran the notebook after changes; tensorboard updates show up regularly.