### PR TITLE
It will generate type error without int

### DIFF
--- a/scientific_details_of_algorithms/streaming_median/streamingMedian.py.ipynb
+++ b/scientific_details_of_algorithms/streaming_median/streamingMedian.py.ipynb
@@ -83,7 +83,7 @@
     "from math import floor\n",
     "def batchMedian(data):\n",
     "    n = len(data)\n",
-    "    median = sorted(data)[floor(n/2)]\n",
+    "    median = sorted(data)[int(floor(n/2))]\n",
     "    return(median)\n",
     "\n",
     "median = batchMedian(data)\n",


### PR DESCRIPTION
The output of floor(n/2) is float