### PR TITLE
Adding a framework version so it doesn't fail.

### DIFF
--- a/sagemaker-python-sdk/tensorflow_resnet_cifar10_with_tensorboard/tensorflow_resnet_cifar10_with_tensorboard.ipynb
+++ b/sagemaker-python-sdk/tensorflow_resnet_cifar10_with_tensorboard/tensorflow_resnet_cifar10_with_tensorboard.ipynb
@@ -118,6 +118,7 @@
     "estimator = TensorFlow(entry_point='resnet_cifar_10.py',\n",
     "                       source_dir=source_dir,\n",
     "                       role=role,\n",
+    "                       framework_version='1.6',\n"
     "                       hyperparameters={'throttle_secs': 30},\n",
     "                       training_steps=1000, evaluation_steps=100,\n",
     "                       train_instance_count=2, train_instance_type='ml.c4.xlarge', \n",


### PR DESCRIPTION
This shall fix the errors of the form:
```
ValueError: Error training tensorboard-example-2018-06-28-23-02-44-061: Failed Reason: AlgorithmError: uncaught exception during training: 'module' object has no attribute 'FixedLengthRecordDataset
```
