### PR TITLE
Rename TF input helper functions.

### DIFF
--- a/sagemaker-python-sdk/tensorflow_abalone_age_predictor_using_keras/abalone.py
+++ b/sagemaker-python-sdk/tensorflow_abalone_age_predictor_using_keras/abalone.py
@@ -71,19 +71,23 @@ params = {"learning_rate": LEARNING_RATE}
 
 
 def train_input_fn(training_dir, params):
-    return _input_fn(training_dir, 'abalone_train.csv')
+    """Returns training input data as a Tuple: (dict of `features`, `targets`)"""
+    return _get_numpy_data(training_dir, 'abalone_train.csv')
 
 
 def eval_input_fn(training_dir, params):
-    return _input_fn(training_dir, 'abalone_test.csv')
+    """Returns evaluation input data as a Tuple: (dict of `features`, `targets`)"""
+    return _get_numpy_data(training_dir, 'abalone_test.csv')
 
 
-def _input_fn(training_dir, training_filename):
+def _get_numpy_data(training_dir, training_filename):
     training_set = tf.contrib.learn.datasets.base.load_csv_without_header(
         filename=os.path.join(training_dir, training_filename), target_dtype=np.int, features_dtype=np.float32)
 
-    return tf.estimator.inputs.numpy_input_fn(
+    numpy_input_fn = tf.estimator.inputs.numpy_input_fn(
         x={INPUT_TENSOR_NAME: np.array(training_set.data)},
         y=np.array(training_set.target),
         num_epochs=None,
-        shuffle=True)()
+        shuffle=True)
+
+    return numpy_input_fn()

--- a/sagemaker-python-sdk/tensorflow_abalone_age_predictor_using_layers/abalone.py
+++ b/sagemaker-python-sdk/tensorflow_abalone_age_predictor_using_layers/abalone.py
@@ -58,19 +58,23 @@ def serving_input_fn(params):
 
 
 def train_input_fn(training_dir, params):
-    return _input_fn(training_dir, 'abalone_train.csv')
+    """Returns training input data as a Tuple: (dict of `features`, `targets`)"""
+    return _get_numpy_data(training_dir, 'abalone_train.csv')
 
 
 def eval_input_fn(training_dir, params):
-    return _input_fn(training_dir, 'abalone_test.csv')
+    """Returns evaluation input data as a Tuple: (dict of `features`, `targets`)"""
+    return _get_numpy_data(training_dir, 'abalone_test.csv')
 
 
-def _input_fn(training_dir, training_filename):
+def _get_numpy_data(training_dir, training_filename):
     training_set = tf.contrib.learn.datasets.base.load_csv_without_header(
         filename=os.path.join(training_dir, training_filename), target_dtype=np.int, features_dtype=np.float32)
 
-    return tf.estimator.inputs.numpy_input_fn(
+    numpy_input_fn = tf.estimator.inputs.numpy_input_fn(
         x={INPUT_TENSOR_NAME: np.array(training_set.data)},
         y=np.array(training_set.target),
         num_epochs=None,
         shuffle=True)()
+
+    return numpy_input_fn()

--- a/sagemaker-python-sdk/tensorflow_distributed_mnist/mnist.py
+++ b/sagemaker-python-sdk/tensorflow_distributed_mnist/mnist.py
@@ -102,14 +102,14 @@ def read_and_decode(filename_queue):
 
 
 def train_input_fn(training_dir, params):
-    return _input_fn(training_dir, 'train.tfrecords', batch_size=100)
+    return _read_tfrecord_data(training_dir, 'train.tfrecords', batch_size=100)
 
 
 def eval_input_fn(training_dir, params):
-    return _input_fn(training_dir, 'test.tfrecords', batch_size=100)
+    return _read_tfrecord_data(training_dir, 'test.tfrecords', batch_size=100)
 
 
-def _input_fn(training_dir, training_filename, batch_size=100):
+def _read_tfrecord_data(training_dir, training_filename, batch_size=100):
     test_file = os.path.join(training_dir, training_filename)
     filename_queue = tf.train.string_input_producer([test_file])
 

--- a/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/iris_dnn_classifier.py
+++ b/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/iris_dnn_classifier.py
@@ -19,23 +19,25 @@ def serving_input_fn(params):
 
 
 def train_input_fn(training_dir, params):
-    """Returns input function that would feed the model during training"""
-    return _generate_input_fn(training_dir, 'iris_training.csv')
+    """Returns training input data as a Tuple: (dict of `features`, `targets`)"""
+    return _get_numpy_data(training_dir, 'iris_training.csv')
 
 
 def eval_input_fn(training_dir, params):
-    """Returns input function that would feed the model during evaluation"""
-    return _generate_input_fn(training_dir, 'iris_test.csv')
+    """Returns evaluation input data as a Tuple: (dict of `features`, `targets`)"""
+    return _get_numpy_data(training_dir, 'iris_test.csv')
 
 
-def _generate_input_fn(training_dir, training_filename):
+def _get_numpy_data(training_dir, training_filename):
     training_set = tf.contrib.learn.datasets.base.load_csv_with_header(
         filename=os.path.join(training_dir, training_filename),
         target_dtype=np.int,
         features_dtype=np.float32)
 
-    return tf.estimator.inputs.numpy_input_fn(
+    numpy_input_fn = tf.estimator.inputs.numpy_input_fn(
         x={INPUT_TENSOR_NAME: np.array(training_set.data)},
         y=np.array(training_set.target),
         num_epochs=None,
-        shuffle=True)()
+        shuffle=True)
+
+    return numpy_input_fn()


### PR DESCRIPTION
Some of our examples were confusing to customers as they implied that
the train_input_fn  was meant to return a function instead of data.

This addresses the misleading comments, also renamed and refactored some
functions to be less ambiguous.