### PR TITLE
object_detection fix visualization

### DIFF
--- a/introduction_to_amazon_algorithms/object_detection_pascalvoc_coco/object_detection_recordio_format.ipynb
+++ b/introduction_to_amazon_algorithms/object_detection_pascalvoc_coco/object_detection_recordio_format.ipynb
@@ -390,7 +390,7 @@
     "\n",
     "object_detector.content_type = 'image/jpeg'\n",
     "results = object_detector.predict(b)\n",
-    "detections = json.loads(results)\n",
+    "detections = json.loads(results)['prediction']\n",
     "print (detections)"
    ]
   },


### PR DESCRIPTION
This commit makes the visualization this notebook work correctly.

Currently the endpoint returns an object that is wrapped in a `{'prediction': []}` object. The visualization does expects the raw predictions array.