### PR TITLE
Update example for TF/MXNet batch transform notebooks

### DIFF
--- a/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist_with_batch_transform.ipynb
+++ b/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist_with_batch_transform.ipynb
@@ -304,7 +304,7 @@
     "    input_file_name = 'data-{}.csv'.format(i)\n",
     "    input_file_key = '{}/{}'.format(input_file_path, input_file_name)\n",
     "    \n",
-    "    s3.Bucket(input_bucket_name).download_file(input_file_key, os.path.join(tmp_dir, input_file_name))\n",
+    "    s3.Bucket(sample_data_bucket).download_file(input_file_key, os.path.join(tmp_dir, input_file_name))\n",
     "    input_data = genfromtxt(os.path.join(tmp_dir, input_file_name), delimiter=',')\n",
     "\n",
     "    show_digit(input_data)"
@@ -337,9 +337,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_tensorflow_p36",
+   "display_name": "conda_mxnet_p36",
    "language": "python",
-   "name": "conda_tensorflow_p36"
+   "name": "conda_mxnet_p36"
   },
   "language_info": {
    "codemirror_mode": {
@@ -351,7 +351,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.4"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },

--- a/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist_with_batch_transform.ipynb
+++ b/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist_with_batch_transform.ipynb
@@ -128,7 +128,7 @@
    "source": [
     "### SageMaker's transformer class\n",
     "\n",
-    "After training, we use our MXNet estimator object to create a `Transformer` by invoking the `transformer()` method. This method takes arguments for configuring our options with the batch transform job; these do not need to be the same values as the one we used for the training job.\n",
+    "After training, we use our MXNet estimator object to create a `Transformer` by invoking the `transformer()` method. This method takes arguments for configuring our options with the batch transform job; these do not need to be the same values as the one we used for the training job. The method also creates a SageMaker Model to be used for the batch transform jobs.\n",
     "\n",
     "The `Transformer` class is responsible for running batch transform jobs, which will deploy the trained model to an endpoint and send requests for performing inference."
    ]

--- a/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist_with_batch_transform.ipynb
+++ b/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist_with_batch_transform.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "isConfigCell": true
    },
@@ -29,18 +29,22 @@
     "from sagemaker import get_execution_role\n",
     "from sagemaker.session import Session\n",
     "\n",
+    "sagemaker_session = Session()\n",
+    "region = sagemaker_session.boto_session.region_name\n",
+    "sample_data_bucket = 'sagemaker-sample-data-{}'.format(region)\n",
+    "\n",
     "# S3 bucket for saving files. Feel free to redefine this variable to the bucket of your choice.\n",
-    "bucket = Session().default_bucket()\n",
+    "bucket = sagemaker_session.default_bucket()\n",
     "\n",
     "# Bucket location where your custom code will be saved in the tar.gz format.\n",
-    "custom_code_upload_location = 's3://{}/customcode/mxnet'.format(bucket)\n",
+    "custom_code_upload_location = 's3://{}/mxnet-mnist-example/code'.format(bucket)\n",
     "\n",
     "# Bucket location where results of model training are saved.\n",
-    "model_artifacts_location = 's3://{}/artifacts'.format(bucket)\n",
+    "model_artifacts_location = 's3://{}/mxnet-mnist-example/artifacts'.format(bucket)\n",
     "\n",
     "# IAM execution role that gives SageMaker access to resources in your AWS account.\n",
     "# We can use the SageMaker Python SDK to get the role from our notebook environment. \n",
-    "role = get_execution_role()"
+    "role = 'SageMakerRole' #get_execution_role()"
    ]
   },
   {
@@ -76,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,14 +112,27 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:sagemaker:Creating training-job with name: sagemaker-mxnet-2018-07-26-00-21-18-448\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "....."
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
-    "import boto3\n",
     "\n",
-    "region = boto3.Session().region_name\n",
-    "train_data_location = 's3://sagemaker-sample-data-{}/mxnet/mnist/train'.format(region)\n",
-    "test_data_location = 's3://sagemaker-sample-data-{}/mxnet/mnist/test'.format(region)\n",
+    "train_data_location = 's3://{}/mxnet/mnist/train'.format(sample_data_bucket)\n",
+    "test_data_location = 's3://{}/mxnet/mnist/test'.format(sample_data_bucket)\n",
     "\n",
     "mnist_estimator.fit({'train': train_data_location, 'test': test_data_location})"
    ]
@@ -148,7 +165,7 @@
     "\n",
     "Now we can perform some inference with the model we've trained by running a batch transform job. The request handling behavior of the Endpoint deployed during the transform job is determined by the `mnist.py` script.\n",
     "\n",
-    "For demonstration purposes, we will be using an image of a '7' that's already saved in S3:"
+    "For demonstration purposes, we're going to use input data that contains ten MNIST images, located in the public SageMaker sample data S3 bucket. To create the batch transform job, we simply call `transform()` on our transformer with information about the input data."
    ]
   },
   {
@@ -157,79 +174,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform_data_location = 's3://sagemaker-sample-data-{}/batch-transform/mnist'.format(region)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Just for fun, we can print out what the image looks like. First we'll create a temporary directory:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
+    "input_file_path = 'batch-transform/mnist/'\n",
     "\n",
-    "tmp_dir = '/tmp/data'\n",
-    "\n",
-    "if not os.path.exists(tmp_dir):\n",
-    "    os.makedirs(tmp_dir)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And now we'll print out the image:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from numpy import genfromtxt\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "plt.rcParams[\"figure.figsize\"] = (2,10)\n",
-    "     \n",
-    "def show_digit(img, caption='', subplot=None):\n",
-    "    if subplot==None:\n",
-    "        _,(subplot)=plt.subplots(1,1)\n",
-    "    imgr=img.reshape((28,28))\n",
-    "    subplot.axis('off')\n",
-    "    subplot.imshow(imgr, cmap='gray')\n",
-    "    plt.title(caption)\n",
-    "     \n",
-    "input_data_file = '/tmp/data/mnist_data.csv'\n",
-    "\n",
-    "s3 = boto3.resource('s3')\n",
-    "s3.Bucket('sagemaker-sample-data-{}'.format(region)).download_file('batch-transform/mnist/data.csv', input_data_file)\n",
-    "\n",
-    "input_data = genfromtxt(input_data_file, delimiter=',')\n",
-    "show_digit(input_data)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we can use the Transformer to classify the handwritten digit:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "transformer.transform(transform_data_location, content_type='text/csv')"
+    "transformer.transform('s3://{}/{}'.format(sample_data_bucket, input_file_path), content_type='text/csv')"
    ]
   },
   {
@@ -270,34 +217,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use that to download the results from S3:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "import json\n",
-    "from urllib.parse import urlparse\n",
-    "     \n",
-    "parsed_url = urlparse(transformer.output_path)\n",
-    "bucket_name = parsed_url.netloc\n",
-    "file_key = '{}/data.csv.out'.format(parsed_url.path[1:])\n",
-    "     \n",
-    "s3 = boto3.resource('s3')\n",
-    "output_obj = s3.Object(bucket_name, file_key)\n",
-    "output = output_obj.get()[\"Body\"].read().decode('utf-8')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The output here is a list of predictions, where each prediction is a list of probabilities, one for each possible label. Since we read the output as a string, we use `ast.literal_eval()` to turn it into a list:"
+    "The output here will be a list of predictions, where each prediction is a list of probabilities, one for each possible label. Since we read the output as a string, we use `ast.literal_eval()` to turn it into a list and find the maximum element of the list gives us the predicted label. Here we define a convenience method to take the output and produce the predicted label."
    ]
   },
   {
@@ -308,15 +228,51 @@
    "source": [
     "import ast\n",
     "\n",
-    "output = ast.literal_eval(output)\n",
-    "probabilities = output[0]"
+    "def predicted_label(transform_output):\n",
+    "    output = ast.literal_eval(transform_output)\n",
+    "    probabilities = output[0]\n",
+    "    prediction = probabilities.index(max(probabilities))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from urllib.parse import urlparse\n",
+    "\n",
+    "import boto3\n",
+    "\n",
+    "parsed_url = urlparse(transformer.output_path)\n",
+    "bucket_name = parsed_url.netloc\n",
+    "prefix = parsed_url.path[1:]\n",
+    "\n",
+    "s3 = boto3.resource('s3')\n",
+    "\n",
+    "predictions = []\n",
+    "for i in range(1):\n",
+    "    output_key = '{}/batch-data-{}.csv.out'.format(prefix, i)\n",
+    "\n",
+    "    output_obj = s3.Object(bucket_name, file_key)\n",
+    "    output = output_obj.get()[\"Body\"].read().decode('utf-8')\n",
+    "    \n",
+    "    prediction.append(predicted_label(output))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have the list of probabilities, finding the maximum element of the list gives us the predicted label:"
+    "For demonstration purposes, we're also going to download the original input data so that we can see how the model did with its predictions."
    ]
   },
   {
@@ -325,16 +281,83 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prediction = probabilities.index(max(probabilities))\n",
-    "print('Prediction is {}'.format(prediction))"
+    "import os\n",
+    "\n",
+    "tmp_dir = '/tmp/data'\n",
+    "\n",
+    "if not os.path.exists(tmp_dir):\n",
+    "    os.makedirs(tmp_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And now we'll print out the image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from numpy import genfromtxt\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.rcParams['figure.figsize'] = (2,10)\n",
+    "\n",
+    "def show_digit(img, caption='', subplot=None):\n",
+    "    if subplot == None:\n",
+    "        _,(subplot) = plt.subplots(1,1)\n",
+    "    imgr = img.reshape((28,28))\n",
+    "    subplot.axis('off')\n",
+    "    subplot.imshow(imgr, cmap='gray')\n",
+    "    plt.title(caption)\n",
+    "\n",
+    "for i in range(10):\n",
+    "    input_file_name = 'data-{}.csv'.format(i)\n",
+    "    input_file_key = '{}/{}'.format(input_file_path, input_file_name)\n",
+    "    \n",
+    "    input_bucket_name = 'sagemaker-us-west-2-583851319346'\n",
+    "    input_file_key = 'data/DEMO-tf-mnist/batch-transform/batch-data-{}.csv'.format(i)\n",
+    "    \n",
+    "    s3.Bucket(input_bucket_name).download_file(input_file_key, os.path.join(tmp_dir, input_file_name))\n",
+    "    input_data = genfromtxt(os.path.join(tmp_dir, input_file_name), delimiter=',')\n",
+    "\n",
+    "    show_digit(input_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "scrolled": true
+   },
+   "source": [
+    "Here, we can see the original labels are:\n",
+    "\n",
+    "```\n",
+    "7, 2, 1, 0, 4, 1, 4, 9, 5, 9\n",
+    "```\n",
+    "\n",
+    "Now let's print out the predictions to compare:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(', '.join(predictions))"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_mxnet_p36",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_mxnet_p36"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -346,7 +369,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.5.3"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },

--- a/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist_with_batch_transform.ipynb
+++ b/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist_with_batch_transform.ipynb
@@ -150,7 +150,7 @@
     "\n",
     "Now we can perform some inference with the model we've trained by running a batch transform job. The request handling behavior of the Endpoint deployed during the transform job is determined by the `mnist.py` script.\n",
     "\n",
-    "For demonstration purposes, we're going to use input data that contains ten MNIST images, located in the public SageMaker sample data S3 bucket. To create the batch transform job, we simply call `transform()` on our transformer with information about the input data."
+    "For demonstration purposes, we're going to use input data that contains 1000 MNIST images, located in the public SageMaker sample data S3 bucket. To create the batch transform job, we simply call `transform()` on our transformer with information about the input data."
    ]
   },
   {
@@ -159,7 +159,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "input_file_path = 'batch-transform/mnist/'\n",
+    "input_file_path = 'batch-transform/mnist-1000-samples'\n",
     "\n",
     "transformer.transform('s3://{}/{}'.format(sample_data_bucket, input_file_path), content_type='text/csv')"
    ]
@@ -223,7 +223,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now download the results from S3:"
+    "Now let's download the first ten results from S3:"
    ]
   },
   {
@@ -257,7 +257,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For demonstration purposes, we're also going to download the original input data so that we can see how the model did with its predictions."
+    "For demonstration purposes, we're also going to download the corresponding original input data so that we can see how the model did with its predictions."
    ]
   },
   {
@@ -278,7 +278,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And now we'll print out the image:"
+    "And now we'll print out the images:"
    ]
   },
   {

--- a/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist_with_batch_transform.ipynb
+++ b/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist_with_batch_transform.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "isConfigCell": true
    },
@@ -44,7 +44,7 @@
     "\n",
     "# IAM execution role that gives SageMaker access to resources in your AWS account.\n",
     "# We can use the SageMaker Python SDK to get the role from our notebook environment. \n",
-    "role = 'SageMakerRole' #get_execution_role()"
+    "role = get_execution_role()"
    ]
   },
   {
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,22 +112,7 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:sagemaker:Creating training-job with name: sagemaker-mxnet-2018-07-26-00-21-18-448\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "....."
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "\n",
@@ -231,15 +216,15 @@
     "def predicted_label(transform_output):\n",
     "    output = ast.literal_eval(transform_output)\n",
     "    probabilities = output[0]\n",
-    "    prediction = probabilities.index(max(probabilities))"
+    "    return probabilities.index(max(probabilities))"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "We now download the results from S3:"
+   ]
   },
   {
    "cell_type": "code",
@@ -259,13 +244,13 @@
     "s3 = boto3.resource('s3')\n",
     "\n",
     "predictions = []\n",
-    "for i in range(1):\n",
-    "    output_key = '{}/batch-data-{}.csv.out'.format(prefix, i)\n",
+    "for i in range(10):\n",
+    "    file_key = '{}/data-{}.csv.out'.format(prefix, i)\n",
     "\n",
     "    output_obj = s3.Object(bucket_name, file_key)\n",
     "    output = output_obj.get()[\"Body\"].read().decode('utf-8')\n",
     "    \n",
-    "    prediction.append(predicted_label(output))"
+    "    predictions.append(predicted_label(output))"
    ]
   },
   {
@@ -319,9 +304,6 @@
     "    input_file_name = 'data-{}.csv'.format(i)\n",
     "    input_file_key = '{}/{}'.format(input_file_path, input_file_name)\n",
     "    \n",
-    "    input_bucket_name = 'sagemaker-us-west-2-583851319346'\n",
-    "    input_file_key = 'data/DEMO-tf-mnist/batch-transform/batch-data-{}.csv'.format(i)\n",
-    "    \n",
     "    s3.Bucket(input_bucket_name).download_file(input_file_key, os.path.join(tmp_dir, input_file_name))\n",
     "    input_data = genfromtxt(os.path.join(tmp_dir, input_file_name), delimiter=',')\n",
     "\n",
@@ -349,15 +331,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(', '.join(predictions))"
+    "print(predictions)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "conda_tensorflow_p36",
    "language": "python",
-   "name": "python3"
+   "name": "conda_tensorflow_p36"
   },
   "language_info": {
    "codemirror_mode": {
@@ -369,7 +351,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.6.5"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },

--- a/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_batch_transform_mnist.ipynb
+++ b/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_batch_transform_mnist.ipynb
@@ -6,15 +6,16 @@
    "source": [
     "# MNIST distributed training and batch transform\n",
     "\n",
-    "The **SageMaker Python SDK** helps you deploy your models for training and hosting in optimized, productions ready containers in SageMaker. The SageMaker Python SDK is easy to use, modular, extensible and compatible with TensorFlow and MXNet. This tutorial focuses on how to create a convolutional neural network model to train the [MNIST dataset](http://yann.lecun.com/exdb/mnist/) using **TensorFlow distributed training**.\n",
-    "\n"
+    "The SageMaker Python SDK helps you deploy your models for training and hosting in optimized, productions ready containers in SageMaker. The SageMaker Python SDK is easy to use, modular, extensible and compatible with TensorFlow and MXNet. This tutorial focuses on how to create a convolutional neural network model to train the [MNIST dataset](http://yann.lecun.com/exdb/mnist/) using TensorFlow distributed training."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Set up the environment"
+    "## Set up the environment\n",
+    "\n",
+    "First, we'll just set up a few things needed for this example"
    ]
   },
   {
@@ -23,13 +24,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "import sagemaker\n",
-    "import boto3\n",
     "from sagemaker import get_execution_role\n",
     "from sagemaker.session import Session\n",
     "\n",
     "sagemaker_session = sagemaker.Session()\n",
+    "region = sagemaker_session.boto_session.region_name\n",
     "\n",
     "role = get_execution_role()"
    ]
@@ -38,7 +38,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Download the MNIST dataset"
+    "### Download the MNIST dataset\n",
+    "\n",
+    "We'll now need to download the MNIST dataset, and upload it to a location in S3 after preparing for training."
    ]
   },
   {
@@ -100,7 +102,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Create a training job using the sagemaker.TensorFlow estimator"
+    "## Create a training job"
    ]
   },
   {
@@ -127,7 +129,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The **```fit```** method will create a training job in two **ml.c4.xlarge** instances. The logs above will show the instances doing training, evaluation, and incrementing the number of **training steps**. \n",
+    "The `fit()` method will create a training job in two ml.c4.xlarge instances. The logs above will show the instances doing training, evaluation, and incrementing the number of training steps. \n",
     "\n",
     "In the end of the training, the training job will generate a saved model for TF serving."
    ]
@@ -136,7 +138,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### SageMaker's transformer class\n",
+    "## SageMaker's transformer class\n",
     "\n",
     "After training, we use our TensorFlow estimator object to create a `Transformer` by invoking the `transformer()` method. This method takes arguments for configuring our options with the batch transform job; these do not need to be the same values as the one we used for the training job.\n",
     "\n",
@@ -156,55 +158,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Inspect input data\n",
+    "# Perform inference\n",
     "\n",
-    "Before we perform the inference let's inspect the input data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import boto3\n",
-    "import matplotlib.pyplot as plt\n",
-    "import os\n",
-    "from numpy import genfromtxt\n",
-    "\n",
-    "plt.rcParams[\"figure.figsize\"] = (2,10)\n",
-    "\n",
-    "def show_digit(img, caption='', subplot=None):\n",
-    "    if subplot==None:\n",
-    "        _,(subplot)=plt.subplots(1,1)\n",
-    "    imgr=img.reshape((28,28))\n",
-    "    subplot.axis('off')\n",
-    "    subplot.imshow(imgr, cmap='gray')\n",
-    "    plt.title(caption)\n",
-    "\n",
-    "tmp_dir = '/tmp/data'\n",
-    "input_file_name = 'data.csv'\n",
-    "input_file_path = 'batch-transform/mnist/' + input_file_name\n",
-    "input_bucket_name = 'sagemaker-sample-data-{}'.format(boto3.Session().region_name)\n",
-    "\n",
-    "if not os.path.exists(tmp_dir):\n",
-    "    os.makedirs(tmp_dir)\n",
-    "\n",
-    "s3 = boto3.resource('s3')\n",
-    "\n",
-    "s3.Bucket(input_bucket_name).download_file(input_file_path, os.path.join(tmp_dir, input_file_name))\n",
-    "input_data = genfromtxt(os.path.join(tmp_dir, input_file_name), delimiter=',')\n",
-    "\n",
-    "show_digit(input_data)"
+    "Now that we've trained a model, we're going to use it to perform inference with a SageMaker batch transform job. The request handling behavior of the Endpoint deployed during the transform job is determined by the `mnist.py` script we looked at earlier."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Running a batch transform job\n",
+    "## Run a batch transform job\n",
     "\n",
-    "Now we can perform some inference with the model we've trained by running a batch transform job. The request handling behavior of the Endpoint deployed during the transform job is determined by the `mnist.py` script."
+    "For our batch transform job, we're going to use input data that contains ten MNIST images, located in the public SageMaker sample data S3 bucket. To create the batch transform job, we simply call `transform()` on our transformer with information about the input data."
    ]
   },
   {
@@ -213,6 +178,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "input_bucket_name = 'sagemaker-sample-data-{}'.format(region)\n",
+    "input_file_path = 'batch-transform/mnist/'\n",
+    "\n",
     "transformer.transform('s3://{}/{}'.format(input_bucket_name, input_file_path), content_type='text/csv')"
    ]
   },
@@ -236,7 +204,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Downloading the results\n",
+    "## Download the results\n",
     "\n",
     "The batch transform job uploads its predictions to S3. Since we did not specify `output_path` when creating the Transformer, one was generated based on the batch transform job name:"
    ]
@@ -266,14 +234,29 @@
     "import json\n",
     "from urllib.parse import urlparse\n",
     "\n",
+    "import boto3\n",
+    "\n",
     "parsed_url = urlparse(transformer.output_path)\n",
     "bucket_name = parsed_url.netloc\n",
-    "file_key = '{}/{}.out'.format(parsed_url.path[1:], input_file_name)\n",
+    "prefix = parsed_url.path[1:]\n",
     "\n",
-    "output_obj = s3.Object(bucket_name, file_key)\n",
-    "output = output_obj.get()[\"Body\"].read()\n",
+    "s3 = boto3.resource('s3')\n",
     "\n",
-    "print('Prediction is {}'.format(json.loads(output)['outputs']['classes']['int64Val']))"
+    "predictions = []\n",
+    "for i in range(10):\n",
+    "    file_key = '{}/data-{}.csv.out'.format(prefix, i)\n",
+    "\n",
+    "    output_obj = s3.Object(bucket_name, file_key)\n",
+    "    output = output_obj.get()[\"Body\"].read().decode('utf-8')\n",
+    "\n",
+    "    predictions.extend(json.loads(output)['outputs']['classes']['int64Val'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For demonstration purposes, we're also going to download the original input data so that we can see how the model did with its predictions."
    ]
   },
   {
@@ -281,7 +264,57 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import os\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from numpy import genfromtxt\n",
+    "\n",
+    "plt.rcParams['figure.figsize'] = (2,10)\n",
+    "\n",
+    "def show_digit(img, caption='', subplot=None):\n",
+    "    if subplot == None:\n",
+    "        _,(subplot) = plt.subplots(1,1)\n",
+    "    imgr = img.reshape((28,28))\n",
+    "    subplot.axis('off')\n",
+    "    subplot.imshow(imgr, cmap='gray')\n",
+    "    plt.title(caption)\n",
+    "\n",
+    "tmp_dir = '/tmp/data'\n",
+    "if not os.path.exists(tmp_dir):\n",
+    "    os.makedirs(tmp_dir)\n",
+    "\n",
+    "for i in range(10):\n",
+    "    input_file_name = 'data-{}.csv'.format(i)\n",
+    "    input_file_key = '{}/{}'.format(input_file_path, input_file_name)\n",
+    "    \n",
+    "    s3.Bucket(input_bucket_name).download_file(input_file_key, os.path.join(tmp_dir, input_file_name))\n",
+    "    input_data = genfromtxt(os.path.join(tmp_dir, input_file_name), delimiter=',')\n",
+    "\n",
+    "    show_digit(input_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, we can see the original labels are:\n",
+    "\n",
+    "```\n",
+    "7, 2, 1, 0, 4, 1, 4, 9, 5, 9\n",
+    "```\n",
+    "\n",
+    "Now let's print out the predictions to compare:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(', '.join(predictions))"
+   ]
   }
  ],
  "metadata": {

--- a/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_batch_transform_mnist.ipynb
+++ b/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_batch_transform_mnist.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# MNIST distributed training and batch transform\n",
     "\n",
-    "The SageMaker Python SDK helps you deploy your models for training and hosting in optimized, productions ready containers in SageMaker. The SageMaker Python SDK is easy to use, modular, extensible and compatible with TensorFlow and MXNet. This tutorial focuses on how to create a convolutional neural network model to train the [MNIST dataset](http://yann.lecun.com/exdb/mnist/) using TensorFlow distributed training."
+    "The SageMaker Python SDK helps you deploy your models for training and hosting in optimized, production-ready containers in SageMaker. The SageMaker Python SDK is easy to use, modular, extensible and compatible with TensorFlow and MXNet. This tutorial focuses on how to create a convolutional neural network model to train the [MNIST dataset](http://yann.lecun.com/exdb/mnist/) using TensorFlow distributed training."
    ]
   },
   {

--- a/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_batch_transform_mnist.ipynb
+++ b/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_batch_transform_mnist.ipynb
@@ -179,7 +179,7 @@
    "outputs": [],
    "source": [
     "input_bucket_name = 'sagemaker-sample-data-{}'.format(region)\n",
-    "input_file_path = 'batch-transform/mnist-1000-samples/'\n",
+    "input_file_path = 'batch-transform/mnist-1000-samples'\n",
     "\n",
     "transformer.transform('s3://{}/{}'.format(input_bucket_name, input_file_path), content_type='text/csv')"
    ]

--- a/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_batch_transform_mnist.ipynb
+++ b/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_batch_transform_mnist.ipynb
@@ -169,7 +169,7 @@
    "source": [
     "## Run a batch transform job\n",
     "\n",
-    "For our batch transform job, we're going to use input data that contains ten MNIST images, located in the public SageMaker sample data S3 bucket. To create the batch transform job, we simply call `transform()` on our transformer with information about the input data."
+    "For our batch transform job, we're going to use input data that contains 1000 MNIST images, located in the public SageMaker sample data S3 bucket. To create the batch transform job, we simply call `transform()` on our transformer with information about the input data."
    ]
   },
   {
@@ -179,7 +179,7 @@
    "outputs": [],
    "source": [
     "input_bucket_name = 'sagemaker-sample-data-{}'.format(region)\n",
-    "input_file_path = 'batch-transform/mnist/'\n",
+    "input_file_path = 'batch-transform/mnist-1000-samples/'\n",
     "\n",
     "transformer.transform('s3://{}/{}'.format(input_bucket_name, input_file_path), content_type='text/csv')"
    ]
@@ -222,7 +222,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use that to download the results from S3:"
+    "Now let's download the first ten results from S3:"
    ]
   },
   {
@@ -256,7 +256,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For demonstration purposes, we're also going to download the original input data so that we can see how the model did with its predictions."
+    "For demonstration purposes, we're also going to download the corresponding original input data so that we can see how the model did with its predictions."
    ]
   },
   {

--- a/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_batch_transform_mnist.ipynb
+++ b/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_batch_transform_mnist.ipynb
@@ -140,7 +140,7 @@
    "source": [
     "## SageMaker's transformer class\n",
     "\n",
-    "After training, we use our TensorFlow estimator object to create a `Transformer` by invoking the `transformer()` method. This method takes arguments for configuring our options with the batch transform job; these do not need to be the same values as the one we used for the training job.\n",
+    "After training, we use our TensorFlow estimator object to create a `Transformer` by invoking the `transformer()` method. This method takes arguments for configuring our options with the batch transform job; these do not need to be the same values as the one we used for the training job. The method also creates a SageMaker Model to be used for the batch transform jobs.\n",
     "\n",
     "The `Transformer` class is responsible for running batch transform jobs, which will deploy the trained model to an endpoint and send requests for performing inference."
    ]


### PR DESCRIPTION
This change is for making a more realistic example input for the batch transform jobs in our example notebooks. As this change is merged, the public sample data buckets will need to be updated for this to work.