### PR TITLE
Disable MKL for TensorFlow iris example to get a better performance. 

### DIFF
--- a/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/iris_dnn_classifier.py
+++ b/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/iris_dnn_classifier.py
@@ -4,6 +4,10 @@ import tensorflow as tf
 
 INPUT_TENSOR_NAME = 'inputs'
 
+# Disable MKL to get a better perfomance for this model.
+os.environ['TF_DISABLE_MKL'] = '1'
+os.environ['TF_DISABLE_POOL_ALLOCATOR'] = '1'
+
 
 def estimator_fn(run_config, params):
     feature_columns = [tf.feature_column.numeric_column(INPUT_TENSOR_NAME, shape=[4])]

--- a/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/tensorflow_iris_dnn_classifier_using_estimators.ipynb
+++ b/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/tensorflow_iris_dnn_classifier_using_estimators.ipynb
@@ -300,6 +300,7 @@
     "\n",
     "iris_estimator = TensorFlow(entry_point='iris_dnn_classifier.py',\n",
     "                            role=role,\n",
+    "                            framework_version='1.8',\n",
     "                            output_path=model_artifacts_location,\n",
     "                            code_location=custom_code_upload_location,\n",
     "                            train_instance_count=1,\n",


### PR DESCRIPTION
Disable MKL for TensorFlow iris example to get a better performance and add explicit framework version for iris example.