### PR TITLE
Removed attachedModel in cleanup to avoid error

### DIFF
--- a/sagemaker-spark/pyspark_mnist/pyspark_mnist_kmeans.ipynb
+++ b/sagemaker-spark/pyspark_mnist/pyspark_mnist_kmeans.ipynb
@@ -505,7 +505,7 @@
     "    resource_cleanup.deleteResources(model.getCreatedResources())\n",
     "\n",
     "# Don't forget to include any models or pipeline models that you created in the notebook\n",
-    "models = [initialModel, attachedModel, retrievedModel, modelFromJob]\n",
+    "models = [initialModel, retrievedModel, modelFromJob]\n",
     "\n",
     "# Delete regular SageMakerModels\n",
     "for m in models:\n",


### PR DESCRIPTION
Attached model is linked to initialModel, so by cleaning up initialModel the resources are already gone when cleaning up attachedModel. 

Fix is to simply remove it from the list of models eligible to clean-up. 