### PR TITLE
Correct typo to avoid confusion on number of endpoints

### DIFF
--- a/sagemaker-spark/pyspark_mnist/pyspark_mnist_pca_mllib_kmeans.ipynb
+++ b/sagemaker-spark/pyspark_mnist/pyspark_mnist_pca_mllib_kmeans.ipynb
@@ -225,7 +225,7 @@
    "source": [
     "## Inference\n",
     "\n",
-    "Let's use our test data on our pipeline by calling `transform`. Please note the below code will take several minutes to run and create the endpoints needed in order to serve this pipeline.  "
+    "Let's use our test data on our pipeline by calling `transform`. Please note the below code will take several minutes to run and create the endpoint needed in order to serve this pipeline.  "
    ]
   },
   {


### PR DESCRIPTION
To avoid confusion around the number of endpoints being created, I propose to have "endpoint" in singular format as only a single endpoint is created in this particular step, contrary to the other notebooks where there can multiple SageMaker endpoints for pipelines. 