### PR TITLE
fix module api link

### DIFF
--- a/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist.ipynb
+++ b/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Training and hosting SageMaker Models using the Apache MXNet Module API\n",
     "\n",
-    "The **SageMaker Python SDK** makes it easy to train and deploy MXNet models. In this example, we train a simple neural network using the Apache MXNet [Module API](https://mxnet.incubator.apache.org/api/python/module.html) and the MNIST dataset. The MNIST dataset is widely used for handwritten digit classification, and consists of 70,000 labeled 28x28 pixel grayscale images of hand-written digits. The dataset is split into 60,000 training images and 10,000 test images. There are 10 classes (one for each of the 10 digits). The task at hand is to train a model using the 60,000 training images and subsequently test its classification accuracy on the 10,000 test images.\n",
+    "The **SageMaker Python SDK** makes it easy to train and deploy MXNet models. In this example, we train a simple neural network using the Apache MXNet [Module API](https://mxnet.apache.org/api/python/module/module.html) and the MNIST dataset. The MNIST dataset is widely used for handwritten digit classification, and consists of 70,000 labeled 28x28 pixel grayscale images of hand-written digits. The dataset is split into 60,000 training images and 10,000 test images. There are 10 classes (one for each of the 10 digits). The task at hand is to train a model using the 60,000 training images and subsequently test its classification accuracy on the 10,000 test images.\n",
     "\n",
     "### Setup\n",
     "\n",


### PR DESCRIPTION
The link in the notebook to the mxnet module api is broken. I think it is supposed to point here..

https://mxnet.apache.org/api/python/module/module.html