### PR TITLE
Fix 404 link to Wikipedia

### DIFF
--- a/sagemaker-python-sdk/tensorflow_abalone_age_predictor_using_keras/tensorflow_abalone_age_predictor_using_keras.ipynb
+++ b/sagemaker-python-sdk/tensorflow_abalone_age_predictor_using_keras/tensorflow_abalone_age_predictor_using_keras.ipynb
@@ -233,7 +233,7 @@
     "\n",
     "*   `tf.nn.relu`. The following code creates a layer of `units` nodes fully\n",
     "    connected to the previous layer `input_layer` with a\n",
-    "    [ReLU activation function](https://en.wikipedia.org/wiki/Rectifier_\\(neural_networks\\))\n",
+    "    [ReLU activation function](https://en.wikipedia.org/wiki/Rectifier_(neural_networks)\n",
     "    (tf.nn.relu):\n",
     "\n",
     "    ```python\n",


### PR DESCRIPTION
Original link sent to a 404: <https://en.wikipedia.org/wiki/Rectifier_/(neural_networks/>

Fixed link send to <https://en.wikipedia.org/wiki/Rectifier_(neural_networks)>

I can't find a way to make the markdown parser add the last `)` to the link, but Wikipedia does a working redirect anyway.