### PR TITLE
Update tensorflow notebooks to use sagemaker tensorflow container 1.9

### DIFF
--- a/sagemaker-python-sdk/tensorflow_abalone_age_predictor_using_keras/tensorflow_abalone_age_predictor_using_keras.ipynb
+++ b/sagemaker-python-sdk/tensorflow_abalone_age_predictor_using_keras/tensorflow_abalone_age_predictor_using_keras.ipynb
@@ -461,6 +461,7 @@
     "\n",
     "abalone_estimator = TensorFlow(entry_point='abalone.py',\n",
     "                               role=role,\n",
+    "                               framework_version='1.9',\n",
     "                               training_steps= 100,                                  \n",
     "                               evaluation_steps= 100,\n",
     "                               hyperparameters={'learning_rate': 0.001},\n",

--- a/sagemaker-python-sdk/tensorflow_abalone_age_predictor_using_layers/tensorflow_abalone_age_predictor_using_layers.ipynb
+++ b/sagemaker-python-sdk/tensorflow_abalone_age_predictor_using_layers/tensorflow_abalone_age_predictor_using_layers.ipynb
@@ -506,6 +506,7 @@
     "\n",
     "abalone_estimator = TensorFlow(entry_point='abalone.py',\n",
     "                               role=role,\n",
+    "                               framework_version='1.9',\n",
     "                               training_steps= 100,                                  \n",
     "                               evaluation_steps= 100,\n",
     "                               hyperparameters={'learning_rate': 0.001},\n",

--- a/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_batch_transform_mnist.ipynb
+++ b/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_batch_transform_mnist.ipynb
@@ -117,6 +117,7 @@
     "\n",
     "mnist_estimator = TensorFlow(entry_point='mnist.py',\n",
     "                             role=role,\n",
+    "                             framework_version='1.9',\n",
     "                             training_steps=1000, \n",
     "                             evaluation_steps=100,\n",
     "                             train_instance_count=2,\n",

--- a/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_distributed_mnist.ipynb
+++ b/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_distributed_mnist.ipynb
@@ -149,6 +149,7 @@
     "\n",
     "mnist_estimator = TensorFlow(entry_point='mnist.py',\n",
     "                             role=role,\n",
+    "                             framework_version='1.9',\n",
     "                             training_steps=1000, \n",
     "                             evaluation_steps=100,\n",
     "                             train_instance_count=2,\n",

--- a/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_local_mode_mnist.ipynb
+++ b/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_local_mode_mnist.ipynb
@@ -165,6 +165,7 @@
     "\n",
     "mnist_estimator = TensorFlow(entry_point='mnist.py',\n",
     "                             role=role,\n",
+    "                             framework_version='1.9',\n",
     "                             training_steps=10, \n",
     "                             evaluation_steps=10,\n",
     "                             train_instance_count=2,\n",

--- a/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/tensorflow_iris_dnn_classifier_using_estimators.ipynb
+++ b/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/tensorflow_iris_dnn_classifier_using_estimators.ipynb
@@ -300,7 +300,7 @@
     "\n",
     "iris_estimator = TensorFlow(entry_point='iris_dnn_classifier.py',\n",
     "                            role=role,\n",
-    "                            framework_version='1.8',\n",
+    "                            framework_version='1.9',\n",
     "                            output_path=model_artifacts_location,\n",
     "                            code_location=custom_code_upload_location,\n",
     "                            train_instance_count=1,\n",

--- a/sagemaker-python-sdk/tensorflow_keras_cifar10/tensorflow_keras_CIFAR10.ipynb
+++ b/sagemaker-python-sdk/tensorflow_keras_cifar10/tensorflow_keras_CIFAR10.ipynb
@@ -216,6 +216,7 @@
     "\n",
     "estimator = TensorFlow(entry_point='cifar10_cnn.py',\n",
     "                       role=role,\n",
+    "                       framework_version='1.9',\n",
     "                       hyperparameters={'learning_rate': 1e-4, 'decay':1e-6},\n",
     "                       training_steps=1000, evaluation_steps=100,\n",
     "                       train_instance_count=1, train_instance_type='ml.c4.xlarge')\n",

--- a/sagemaker-python-sdk/tensorflow_pipemode_example/tensorflow_pipemode_example.ipynb
+++ b/sagemaker-python-sdk/tensorflow_pipemode_example/tensorflow_pipemode_example.ipynb
@@ -132,6 +132,7 @@
     "\n",
     "tensorflow = TensorFlow(entry_point='pipemode.py',\n",
     "                        role=role,\n",
+    "                        framework_version='1.9',\n",
     "                        input_mode='Pipe',\n",
     "                        output_path=model_artifacts_location,\n",
     "                        code_location=custom_code_upload_location,\n",

--- a/sagemaker-python-sdk/tensorflow_resnet_cifar10_with_tensorboard/tensorflow_resnet_cifar10_with_tensorboard.ipynb
+++ b/sagemaker-python-sdk/tensorflow_resnet_cifar10_with_tensorboard/tensorflow_resnet_cifar10_with_tensorboard.ipynb
@@ -118,7 +118,7 @@
     "estimator = TensorFlow(entry_point='resnet_cifar_10.py',\n",
     "                       source_dir=source_dir,\n",
     "                       role=role,\n",
-    "                       framework_version='1.8',\n",
+    "                       framework_version='1.9',\n",
     "                       hyperparameters={'throttle_secs': 30},\n",
     "                       training_steps=1000, evaluation_steps=100,\n",
     "                       train_instance_count=2, train_instance_type='ml.c4.xlarge', \n",


### PR DESCRIPTION
In all tensorflow notebooks, explicitly pass framework version as argument. This is helpful because:

1. Users know which version they are using
2. We can freeze versions to older ones if new ones have bugs that cannot be fixed in short time

For now I tested all notebooks and pass version 1.9