### PR TITLE
Fix #410: Documentation code should not run

### DIFF
--- a/sagemaker-python-sdk/tensorflow_pipemode_example/tensorflow_pipemode_example.ipynb
+++ b/sagemaker-python-sdk/tensorflow_pipemode_example/tensorflow_pipemode_example.ipynb
@@ -25,22 +25,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "isConfigCell": true
    },
    "outputs": [],
    "source": [
     "from sagemaker import get_execution_role\n",
+    "#IAM execution role that gives SageMaker access to resources in your AWS account.\n",
+    "role = get_execution_role()\n",
     "\n",
     "#Bucket location to save your custom code in tar.gz format.\n",
-    "custom_code_upload_location = 's3://<bucket-name>/customcode/tensorflow_pipemode'\n",
+    "bucket = '<bucket-name>'\n",
+    "custom_code_upload_location = 's3://{}/customcode/tensorflow_pipemode'.format(bucket)\n",
     "\n",
     "#Bucket location where results of model training are saved.\n",
-    "model_artifacts_location = 's3://<bucket-name>/artifacts'\n",
-    "\n",
-    "#IAM execution role that gives SageMaker access to resources in your AWS account.\n",
-    "role = get_execution_role()\n"
+    "model_artifacts_location = 's3://{}/artifacts'.format(bucket)"
    ]
   },
   {
@@ -65,6 +65,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The above script implements all the functions required for a sagemaker tensorflow training script (See: [Preparing TensorFlow Training Script](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/tensorflow/README.rst#preparing-the-tensorflow-training-script)). "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Using a PipeModeDataset in an input_fn\n",
     "To train an estimator using a Pipe Mode channel, we must construct an input_fn that reads from the channel. To do this, we use the SageMaker PipeModeDataset. This is a TensorFlow Dataset specifically created to read from a SageMaker Pipe Mode channel. A PipeModeDataset is a fully-featured TensorFlow Dataset and can be used in exactly the same ways as a regular TensorFlow Dataset can be used.\n",
     "\n",
@@ -72,15 +79,9 @@
     "\n",
     "The training and evaluation data were produced using the benchmarking source code in the sagemaker-tensorflow-extensions benchmarking sub-package. If you want to investigate this further, please visit the GitHub repository for sagemaker-tensorflow-extensions at https://github.com/aws/sagemaker-tensorflow-extensions. \n",
     "\n",
-    "The following example code shows how to use a PipeModeDataset in an input_fn."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "The following example code shows how to use a PipeModeDataset in an input_fn.\n",
+    "\n",
+    "```python\n",
     "from sagemaker_tensorflow import PipeModeDataset\n",
     "\n",
     "def input_fn():\n",
@@ -107,7 +108,8 @@
     "    ds = ds.map(parse, num_parallel_calls=10)\n",
     "    ds = ds.batch(64)\n",
     "    \n",
-    "    return ds"
+    "    return ds\n",
+    "```"
    ]
   },
   {


### PR DESCRIPTION
Convert code cell that was not intended to run into markdown so that all cells in the notebook can be run without error.