### PR TITLE
Add regional S3 endpoint to PySpark notebooks

### DIFF
--- a/sagemaker-spark/pyspark_mnist/pyspark_mnist_custom_estimator.ipynb
+++ b/sagemaker-spark/pyspark_mnist/pyspark_mnist_custom_estimator.ipynb
@@ -94,6 +94,7 @@
     "import boto3\n",
     "\n",
     "region = boto3.Session().region_name\n",
+    "spark._jsc.hadoopConfiguration().set('fs.s3a.endpoint', 's3.{}.amazonaws.com'.format(region))\n",
     "\n",
     "trainingData = spark.read.format('libsvm')\\\n",
     "    .option('numFeatures', '784')\\\n",

--- a/sagemaker-spark/pyspark_mnist/pyspark_mnist_kmeans.ipynb
+++ b/sagemaker-spark/pyspark_mnist/pyspark_mnist_kmeans.ipynb
@@ -95,6 +95,7 @@
     "import boto3\n",
     "\n",
     "region = boto3.Session().region_name\n",
+    "spark._jsc.hadoopConfiguration().set('fs.s3a.endpoint', 's3.{}.amazonaws.com'.format(region))\n",
     "\n",
     "trainingData = spark.read.format('libsvm')\\\n",
     "    .option('numFeatures', '784')\\\n",

--- a/sagemaker-spark/pyspark_mnist/pyspark_mnist_pca_kmeans.ipynb
+++ b/sagemaker-spark/pyspark_mnist/pyspark_mnist_pca_kmeans.ipynb
@@ -94,6 +94,7 @@
     "import boto3\n",
     "\n",
     "region = boto3.Session().region_name\n",
+    "spark._jsc.hadoopConfiguration().set('fs.s3a.endpoint', 's3.{}.amazonaws.com'.format(region))\n",
     "\n",
     "trainingData = spark.read.format('libsvm')\\\n",
     "    .option('numFeatures', '784')\\\n",

--- a/sagemaker-spark/pyspark_mnist/pyspark_mnist_pca_mllib_kmeans.ipynb
+++ b/sagemaker-spark/pyspark_mnist/pyspark_mnist_pca_mllib_kmeans.ipynb
@@ -98,6 +98,7 @@
     "import boto3\n",
     "\n",
     "region = boto3.Session().region_name\n",
+    "spark._jsc.hadoopConfiguration().set('fs.s3a.endpoint', 's3.{}.amazonaws.com'.format(region))\n",
     "\n",
     "trainingData = spark.read.format('libsvm')\\\n",
     "    .option('numFeatures', '784')\\\n",

--- a/sagemaker-spark/pyspark_mnist/pyspark_mnist_xgboost.ipynb
+++ b/sagemaker-spark/pyspark_mnist/pyspark_mnist_xgboost.ipynb
@@ -97,6 +97,7 @@
     "import boto3\n",
     "\n",
     "region = boto3.Session().region_name\n",
+    "spark._jsc.hadoopConfiguration().set('fs.s3a.endpoint', 's3.{}.amazonaws.com'.format(region))\n",
     "\n",
     "trainingData = spark.read.format('libsvm')\\\n",
     "    .option('numFeatures', '784')\\\n",


### PR DESCRIPTION
The PySpark notebooks don't currently use a regional endpoint for pulling data from S3.