### PR TITLE
Use http instead of S3 URI for PyTorch LSTM notebook

### DIFF
--- a/sagemaker-python-sdk/pytorch_lstm_word_language_model/pytorch_rnn.ipynb
+++ b/sagemaker-python-sdk/pytorch_lstm_word_language_model/pytorch_rnn.ipynb
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "aws s3 cp s3://research.metamind.io/wikitext/wikitext-2-raw-v1.zip wikitext-2-raw-v1.zip\n",
+    "wget http://research.metamind.io.s3.amazonaws.com/wikitext/wikitext-2-raw-v1.zip\n",
     "unzip -n wikitext-2-raw-v1.zip\n",
     "cd wikitext-2-raw\n",
     "mv wiki.test.raw test && mv wiki.train.raw train && mv wiki.valid.raw valid\n"


### PR DESCRIPTION
For compatibility with all regions.