### PR TITLE
Freezing TF version on HPO BYOC example

### DIFF
--- a/hyperparameter_tuning/keras_bring_your_own/hpo_bring_your_own_keras_container.ipynb
+++ b/hyperparameter_tuning/keras_bring_your_own/hpo_bring_your_own_keras_container.ipynb
@@ -116,7 +116,7 @@
     "\n",
     "#version tag can be found at https://hub.docker.com/r/tensorflow/tensorflow/tags/ \n",
     "#e.g., latest cpu version is 'latest', while latest gpu version is 'latest-gpu'\n",
-    "tensorflow_version_tag = 'latest'   \n",
+    "tensorflow_version_tag = '1.10.1'   \n",
     "\n",
     "account = boto3.client('sts').get_caller_identity()['Account']\n",
     "    \n",


### PR DESCRIPTION
Freezing TF version on HPO BYOC example to avoid breaking when version changes.