### PR TITLE
Fixing recommender example

### DIFF
--- a/introduction_to_applying_machine_learning/gluon_recommender_system/gluon_recommender_system.ipynb
+++ b/introduction_to_applying_machine_learning/gluon_recommender_system/gluon_recommender_system.ipynb
@@ -372,7 +372,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "num_embeddings = 256\n",
+    "num_embeddings = 64\n",
     "\n",
     "net = MFBlock(max_users=customer_index.shape[0], \n",
     "              max_items=product_index.shape[0],\n",
@@ -563,7 +563,7 @@
    "source": [
     "We can see that this correlation is nearly perfect.  Essentially the average rating of items dominates across users and we'll recommend the same well-reviewed items to everyone.  As it turns out, we can add more embeddings and this relationship will go away since we're better able to capture differential preferences across users.\n",
     "\n",
-    "However, with just a 64 dimensional embedding, it took 40 minutes to run just 3 epochs.  If we ran this outside of our Notebook Instance we could run larger jobs and move on to other work would improve productivity.\n",
+    "However, with just a 64 dimensional embedding, it took 7 minutes to run just 3 epochs.  If we ran this outside of our Notebook Instance we could run larger jobs and move on to other work would improve productivity.\n",
     "\n",
     "---\n",
     "\n",
@@ -675,7 +675,8 @@
     "                           'lr': lr, \n",
     "                           'momentum': momentum, \n",
     "                           'wd': wd,\n",
-    "                           'epochs': 10})\n",
+    "                           'epochs': 10},\n",
+    "         framework_version='1.1')\n",
     "\n",
     "m.fit({'train': 's3://{}/{}/train/'.format(bucket, prefix)})"
    ]

--- a/introduction_to_applying_machine_learning/gluon_recommender_system/gluon_recommender_system.ipynb
+++ b/introduction_to_applying_machine_learning/gluon_recommender_system/gluon_recommender_system.ipynb
@@ -397,7 +397,7 @@
    "source": [
     "# Initialize network parameters\n",
     "ctx = mx.gpu()\n",
-    "net.collect_params().initialize(mx.init.Xavier(magnitude=2.24),\n",
+    "net.collect_params().initialize(mx.init.Xavier(magnitude=60),\n",
     "                                ctx=ctx,\n",
     "                                force_reinit=True)\n",
     "net.hybridize()\n",

--- a/introduction_to_applying_machine_learning/gluon_recommender_system/gluon_recommender_system.ipynb
+++ b/introduction_to_applying_machine_learning/gluon_recommender_system/gluon_recommender_system.ipynb
@@ -64,7 +64,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "isConfigCell": true
    },
    "outputs": [],
@@ -119,9 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!mkdir /tmp/recsys/\n",
@@ -177,9 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df = df[['customer_id', 'product_id', 'star_rating', 'product_title']]"
@@ -220,9 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "customers = customers[customers >= 5]\n",
@@ -241,9 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "customers = reduced_df['customer_id'].value_counts()\n",
@@ -283,9 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "test_df = reduced_df.groupby('customer_id').last().reset_index()\n",
@@ -301,59 +290,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we'll prepare for MXNet.  The data is sparse, so we'll first create a sparse matrix class that takes in our features (user and item indices) and our label (the star rating for that user-item combination).  This actually represents our data as a long list of (row index, column index, rating) values, rather than the large sparse user-item matrix shown above.  However, it doesn't change the mathematics of our model."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "class SparseMatrixDataset(gluon.data.Dataset):\n",
-    "    def __init__(self, data, label):\n",
-    "        assert data.shape[0] == len(label)\n",
-    "        self.data = data\n",
-    "        self.label = label\n",
-    "        if isinstance(label, ndarray.NDArray) and len(label.shape) == 1:\n",
-    "            self._label = label.asnumpy()\n",
-    "        else:\n",
-    "            self._label = label       \n",
-    "        \n",
-    "    def __getitem__(self, idx):\n",
-    "        return self.data[idx, 0], self.data[idx, 1], self.label[idx]\n",
-    "    \n",
-    "    def __len__(self):\n",
-    "        return self.data.shape[0]        "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Now, we can convert our Pandas DataFrames into MXNet NDArrays, use those to create a member of the SparseMatrixDataset class, and add that to an MXNet Data Iterator.  This process is the same for both test and control."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "batch_size = 40\n",
+    "batch_size = 1024\n",
     "\n",
-    "train_iter = gluon.data.DataLoader(SparseMatrixDataset(nd.array(train_df[['user', 'item']].values, dtype=np.float32), \n",
-    "                                                       nd.array(train_df['star_rating'].values, dtype=np.float32)), \n",
-    "                                   shuffle=True,\n",
-    "                                   batch_size=batch_size)\n",
-    "test_iter = gluon.data.DataLoader(SparseMatrixDataset(nd.array(test_df[['user', 'item']].values, dtype=np.float32), \n",
-    "                                                      nd.array(test_df['star_rating'].values, dtype=np.float32)),\n",
-    "                                  shuffle=True,\n",
-    "                                  batch_size=batch_size)"
+    "train = gluon.data.ArrayDataset(nd.array(train_df['user'].values, dtype=np.float32),\n",
+    "                                nd.array(train_df['item'].values, dtype=np.float32),\n",
+    "                                nd.array(train_df['star_rating'].values, dtype=np.float32))\n",
+    "test  = gluon.data.ArrayDataset(nd.array(test_df['user'].values, dtype=np.float32),\n",
+    "                                nd.array(test_df['item'].values, dtype=np.float32),\n",
+    "                                nd.array(test_df['star_rating'].values, dtype=np.float32))\n",
+    "\n",
+    "train_iter = gluon.data.DataLoader(train, shuffle=True, num_workers=4, batch_size=batch_size, last_batch='rollover')\n",
+    "test_iter = gluon.data.DataLoader(train, shuffle=True, num_workers=4, batch_size=batch_size, last_batch='rollover')"
    ]
   },
   {
@@ -376,9 +332,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class MFBlock(gluon.HybridBlock):\n",
@@ -393,17 +347,21 @@
     "        with self.name_scope():\n",
     "            self.user_embeddings = gluon.nn.Embedding(max_users, num_emb)\n",
     "            self.item_embeddings = gluon.nn.Embedding(max_items, num_emb)\n",
-    "            self.dropout = gluon.nn.Dropout(dropout_p)\n",
-    "            self.dense = gluon.nn.Dense(num_emb, activation='relu')\n",
+    "            \n",
+    "            self.dropout_user = gluon.nn.Dropout(dropout_p)\n",
+    "            self.dropout_item = gluon.nn.Dropout(dropout_p)\n",
+    "\n",
+    "            self.dense_user   = gluon.nn.Dense(num_emb, activation='relu')\n",
+    "            self.dense_item = gluon.nn.Dense(num_emb, activation='relu')\n",
     "            \n",
     "    def hybrid_forward(self, F, users, items):\n",
     "        a = self.user_embeddings(users)\n",
-    "        a = self.dense(a)\n",
+    "        a = self.dense_user(a)\n",
     "        \n",
     "        b = self.item_embeddings(items)\n",
-    "        b = self.dense(b)\n",
+    "        b = self.dense_item(b)\n",
     "\n",
-    "        predictions = self.dropout(a) * self.dropout(b)      \n",
+    "        predictions = self.dropout_user(a) * self.dropout_item(b)     \n",
     "        predictions = F.sum(predictions, axis=1)\n",
     "        return predictions"
    ]
@@ -414,13 +372,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "num_embeddings = 64\n",
+    "num_embeddings = 256\n",
     "\n",
     "net = MFBlock(max_users=customer_index.shape[0], \n",
     "              max_items=product_index.shape[0],\n",
     "              num_emb=num_embeddings,\n",
-    "              dropout_p=0.)\n",
-    "net.collect_params()"
+    "              dropout_p=0.5)\n"
    ]
   },
   {
@@ -435,9 +392,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initialize network parameters\n",
@@ -472,27 +427,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def execute(train_iter, test_iter, net, epochs, ctx):\n",
+    "    \n",
     "    loss_function = gluon.loss.L2Loss()\n",
     "    for e in range(epochs):\n",
+    "        \n",
     "        print(\"epoch: {}\".format(e))\n",
+    "        \n",
     "        for i, (user, item, label) in enumerate(train_iter):\n",
-    "            try:\n",
-    "                user = user.as_in_context(ctx).reshape((batch_size,))\n",
-    "                item = item.as_in_context(ctx).reshape((batch_size,))\n",
-    "                label = label.as_in_context(ctx).reshape((batch_size,))\n",
+    "                user = user.as_in_context(ctx)\n",
+    "                item = item.as_in_context(ctx)\n",
+    "                label = label.as_in_context(ctx)\n",
+    "                \n",
     "                with mx.autograd.record():\n",
     "                    output = net(user, item)               \n",
     "                    loss = loss_function(output, label)\n",
+    "                    \n",
     "                loss.backward()\n",
     "                trainer.step(batch_size)\n",
-    "            except:\n",
-    "                pass\n",
+    "\n",
     "        print(\"EPOCH {}: MSE ON TRAINING and TEST: {}. {}\".format(e,\n",
     "                                                                   eval_net(train_iter, net, ctx, loss_function),\n",
     "                                                                   eval_net(test_iter, net, ctx, loss_function)))\n",
@@ -510,22 +466,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def eval_net(data, net, ctx, loss_function):\n",
     "    acc = MSE()\n",
     "    for i, (user, item, label) in enumerate(data):\n",
-    "        try:\n",
-    "            user = user.as_in_context(ctx).reshape((batch_size,))\n",
-    "            item = item.as_in_context(ctx).reshape((batch_size,))\n",
-    "            label = label.as_in_context(ctx).reshape((batch_size, 1))\n",
+    "        \n",
+    "            user = user.as_in_context(ctx)\n",
+    "            item = item.as_in_context(ctx)\n",
+    "            label = label.as_in_context(ctx)\n",
     "            predictions = net(user, item).reshape((batch_size, 1))\n",
     "            acc.update(preds=[predictions], labels=[label])\n",
-    "        except:\n",
-    "            pass\n",
+    "   \n",
     "    return acc.get()[1]"
    ]
   },
@@ -650,9 +603,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# %%time\n",
@@ -683,9 +634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "boto3.client('s3').copy({'Bucket': 'amazon-reviews-pds', \n",
@@ -853,9 +802,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "predictions = []\n",
@@ -933,9 +880,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sagemaker.Session().delete_endpoint(predictor.endpoint)"

--- a/introduction_to_applying_machine_learning/gluon_recommender_system/recommender.py
+++ b/introduction_to_applying_machine_learning/gluon_recommender_system/recommender.py
@@ -30,7 +30,7 @@ def train(channel_input_dirs, hyperparameters, hosts, num_gpus, **kwargs):
     train_iter, test_iter, customer_index, product_index = prepare_train_data(training_dir)
     
     # get hyperparameters
-    num_embeddings = hyperparameters.get('num_embeddings', 256)
+    num_embeddings = hyperparameters.get('num_embeddings', 64)
     opt = hyperparameters.get('opt', 'sgd')
     lr = hyperparameters.get('lr', 0.02)
     momentum = hyperparameters.get('momentum', 0.9)

--- a/introduction_to_applying_machine_learning/gluon_recommender_system/recommender.py
+++ b/introduction_to_applying_machine_learning/gluon_recommender_system/recommender.py
@@ -45,7 +45,7 @@ def train(channel_input_dirs, hyperparameters, hosts, num_gpus, **kwargs):
                   num_emb=num_embeddings,
                   dropout_p=0.5)
     
-    net.collect_params().initialize(mx.init.Xavier(magnitude=2.24),
+    net.collect_params().initialize(mx.init.Xavier(magnitude=60),
                                     ctx=ctx,
                                     force_reinit=True)
     net.hybridize()

--- a/introduction_to_applying_machine_learning/gluon_recommender_system/recommender.py
+++ b/introduction_to_applying_machine_learning/gluon_recommender_system/recommender.py
@@ -16,7 +16,7 @@ logging.basicConfig(level=logging.DEBUG)
 # Globals
 #########
 
-batch_size = 40
+batch_size = 1024
 
 
 ##########
@@ -30,7 +30,7 @@ def train(channel_input_dirs, hyperparameters, hosts, num_gpus, **kwargs):
     train_iter, test_iter, customer_index, product_index = prepare_train_data(training_dir)
     
     # get hyperparameters
-    num_embeddings = hyperparameters.get('num_embeddings', 64)
+    num_embeddings = hyperparameters.get('num_embeddings', 256)
     opt = hyperparameters.get('opt', 'sgd')
     lr = hyperparameters.get('lr', 0.02)
     momentum = hyperparameters.get('momentum', 0.9)
@@ -43,8 +43,7 @@ def train(channel_input_dirs, hyperparameters, hosts, num_gpus, **kwargs):
     net = MFBlock(max_users=customer_index.shape[0], 
                   max_items=product_index.shape[0],
                   num_emb=num_embeddings,
-                  dropout_p=0.)
-    net.collect_params()
+                  dropout_p=0.5)
     
     net.collect_params().initialize(mx.init.Xavier(magnitude=2.24),
                                     ctx=ctx,
@@ -75,18 +74,23 @@ class MFBlock(gluon.HybridBlock):
         with self.name_scope():
             self.user_embeddings = gluon.nn.Embedding(max_users, num_emb)
             self.item_embeddings = gluon.nn.Embedding(max_items, num_emb)
-            self.dropout = gluon.nn.Dropout(dropout_p)
-            self.dense = gluon.nn.Dense(num_emb, activation='relu')
+
+            self.dropout_user = gluon.nn.Dropout(dropout_p)
+            self.dropout_item = gluon.nn.Dropout(dropout_p)
+
+            self.dense_user   = gluon.nn.Dense(num_emb, activation='relu')
+            self.dense_item = gluon.nn.Dense(num_emb, activation='relu')
             
     def hybrid_forward(self, F, users, items):
         a = self.user_embeddings(users)
-        a = self.dense(a)
+        a = self.dense_user(a)
         
         b = self.item_embeddings(items)
-        b = self.dense(b)
+        b = self.dense_item(b)
 
-        predictions = self.dropout(a) * self.dropout(b)      
+        predictions = self.dropout_user(a) * self.dropout_item(b)      
         predictions = F.sum(predictions, axis=1)
+
         return predictions
 
     
@@ -95,17 +99,17 @@ def execute(train_iter, test_iter, net, trainer, epochs, ctx):
     for e in range(epochs):
         print("epoch: {}".format(e))
         for i, (user, item, label) in enumerate(train_iter):
-            try:
-                user = user.as_in_context(ctx).reshape((batch_size,))
-                item = item.as_in_context(ctx).reshape((batch_size,))
-                label = label.as_in_context(ctx).reshape((batch_size,))
+
+                user = user.as_in_context(ctx)
+                item = item.as_in_context(ctx)
+                label = label.as_in_context(ctx)
+
                 with mx.autograd.record():
                     output = net(user, item)               
                     loss = loss_function(output, label)
                 loss.backward()
                 trainer.step(batch_size)
-            except:
-                pass
+
         print("EPOCH {}: MSE ON TRAINING and TEST: {}. {}".format(e,
                                                                    eval_net(train_iter, net, ctx, loss_function),
                                                                    eval_net(test_iter, net, ctx, loss_function)))
@@ -116,14 +120,14 @@ def execute(train_iter, test_iter, net, trainer, epochs, ctx):
 def eval_net(data, net, ctx, loss_function):
     acc = MSE()
     for i, (user, item, label) in enumerate(data):
-        try:
-            user = user.as_in_context(ctx).reshape((batch_size,))
-            item = item.as_in_context(ctx).reshape((batch_size,))
-            label = label.as_in_context(ctx).reshape((batch_size, 1))
+
+            user = user.as_in_context(ctx)
+            item = item.as_in_context(ctx)
+            label = label.as_in_context(ctx)
+
             predictions = net(user, item).reshape((batch_size, 1))
             acc.update(preds=[predictions], labels=[label])
-        except:
-            pass
+
     return acc.get()[1]
 
 
@@ -145,23 +149,6 @@ def save(model, model_dir):
 # Data
 ######
 
-class SparseMatrixDataset(gluon.data.Dataset):
-    def __init__(self, data, label):
-        assert data.shape[0] == len(label)
-        self.data = data
-        self.label = label
-        if isinstance(label, ndarray.NDArray) and len(label.shape) == 1:
-            self._label = label.asnumpy()
-        else:
-            self._label = label       
-        
-    def __getitem__(self, idx):
-        return self.data[idx, 0], self.data[idx, 1], self.label[idx]
-    
-    def __len__(self):
-        return self.data.shape[0]        
-
-    
 def prepare_train_data(training_dir):
     f = os.listdir(training_dir)
     df = pd.read_csv(os.path.join(training_dir, f[0]), delimiter='\t', error_bad_lines=False)
@@ -193,17 +180,17 @@ def prepare_train_data(training_dir):
     train_df = train_df[(train_df['_merge'] == 'left_only')]
 
     # MXNet data iterators
-    train_iter = gluon.data.DataLoader(SparseMatrixDataset(nd.array(train_df[['user', 'item']].values, dtype=np.float32), 
-                                                           nd.array(train_df['star_rating'].values, dtype=np.float32)), 
-                                       shuffle=True,
-                                       batch_size=batch_size)
-    test_iter = gluon.data.DataLoader(SparseMatrixDataset(nd.array(test_df[['user', 'item']].values, dtype=np.float32), 
-                                                          nd.array(test_df['star_rating'].values, dtype=np.float32)),
-                                      shuffle=True,
-                                      batch_size=batch_size)
+    train = gluon.data.ArrayDataset(nd.array(train_df['user'].values, dtype=np.float32), 
+                                    nd.array(train_df['item'].values, dtype=np.float32),
+                                    nd.array(train_df['star_rating'].values, dtype=np.float32))
+    test  = gluon.data.ArrayDataset(nd.array(test_df['user'].values, dtype=np.float32), 
+                                    nd.array(test_df['item'].values, dtype=np.float32),
+                                    nd.array(test_df['star_rating'].values, dtype=np.float32))
+
+    train_iter = gluon.data.DataLoader(train, shuffle=True, num_workers=4, batch_size=batch_size, last_batch='rollover')
+    test_iter = gluon.data.DataLoader(train, shuffle=True, num_workers=4, batch_size=batch_size, last_batch='rollover')
 
     return train_iter, test_iter, customer_index, product_index 
-
 
 #########
 # Hosting


### PR DESCRIPTION
I changed a couple of issues in the Gluon recommender example. 
It has been using an unnecessary ```try except``` block within the training loop. I assume ```try except``` was in place to avoid the issue when the last batch did not have the required batch_size and as such ```net(user, item)``` would throw an error. However, ```try except``` does not work here, because MXNet's engine would crash and not recover. Consequently, the Python interpreter is stuck.
To avoid this issue, the Dataloader has to be modified. The argument ```last_batch='rollover'``` makes sure that the last batch will be rolled over to next iteration, if it is not large enough.

It also appears, that ```SparseMatrixDataset(gluon.data.Dataset)``` is unnecessary. You can just use ```gluon.data.ArrayDataset(nd.array(train_df['user'].values, dtype=np.float32),
                                nd.array(train_df['item'].values, dtype=np.float32),
                                nd.array(train_df['star_rating'].values, dtype=np.float32))```

I also added ```num_workers=4``` in the DataLoader and increased the batch_size to increase GPU utilization.

I also modified the model itself, since it was using the same Dense layer for ```user``` and ```item``` which can be bad for training performance.  Dropout was set to 0 which means there was no Dropout applied. 