### PR TITLE
Fix prediction data in tensorflow keras notebook

### DIFF
--- a/sagemaker-python-sdk/tensorflow_keras_cifar10/cifar10_cnn.py
+++ b/sagemaker-python-sdk/tensorflow_keras_cifar10/cifar10_cnn.py
@@ -90,7 +90,7 @@ def serving_input_fn(hyperparameters):
     # Notice that the input placeholder has the same input shape as the Keras model input
     tensor = tf.placeholder(tf.float32, shape=[None, HEIGHT, WIDTH, DEPTH])
     
-    # The inputs key PREDICT_INPUTS matches the Keras InputLayer name
+    # The inputs key INPUT_TENSOR_NAME matches the Keras InputLayer name
     inputs = {INPUT_TENSOR_NAME: tensor}
     return tf.estimator.export.ServingInputReceiver(inputs, inputs)
 

--- a/sagemaker-python-sdk/tensorflow_keras_cifar10/tensorflow_keras_CIFAR10.ipynb
+++ b/sagemaker-python-sdk/tensorflow_keras_cifar10/tensorflow_keras_CIFAR10.ipynb
@@ -186,8 +186,8 @@
     "    # Notice that the input placeholder has the same input shape as the Keras model input\n",
     "    tensor = tf.placeholder(tf.float32, shape=[None, HEIGHT, WIDTH, DEPTH])\n",
     "    \n",
-    "    # The inputs key PREDICT_INPUTS matches the Keras InputLayer name\n",
-    "    inputs = {PREDICT_INPUTS: tensor}\n",
+    "    # The inputs key INPUT_TENSOR_NAME matches the Keras InputLayer name\n",
+    "    inputs = {INPUT_TENSOR_NAME: tensor}\n",
     "    return tf.estimator.export.ServingInputReceiver(inputs, inputs)\n",
     "\n",
     "\n",
@@ -269,7 +269,8 @@
     "import numpy as np\n",
     "data = np.random.randn(1, 32, 32, 3)\n",
     "\n",
-    "predictor.predict(data)"
+    "# The inputs key 'inputs_input' matches the Keras InputLayer name\n",
+    "predictor.predict({'inputs_input': data}) "
    ]
   },
   {


### PR DESCRIPTION
Current prediction part in tensorflow keras notebook will get following error:

ModelError: An error occurred (ModelError) when calling the InvokeEndpoint operation: Received server error (500) from model with message

The reason is the data format doesn't match InputLayer's name. So we need to add 'inputs_input' as the key in prediction data where 'inputs' is name of InputLayer and '_input' is the required name postfix by Keras.