### PR TITLE
Xgboost region repair

### DIFF
--- a/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
@@ -42,7 +42,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "isConfigCell": true
    },
    "outputs": [],
@@ -75,9 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -144,9 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -183,9 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
@@ -195,9 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -302,9 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -342,9 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from time import gmtime, strftime\n",
@@ -375,7 +362,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -415,9 +401,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "runtime_client = boto3.client('runtime.sagemaker', region_name=region)"
@@ -433,9 +417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!head -1 abalone.test > abalone.single.test"
@@ -444,9 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -479,9 +459,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import sys\n",
@@ -523,7 +501,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -553,9 +530,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "client.delete_endpoint(EndpointName=endpoint_name)"
@@ -565,21 +540,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "conda_chainer_p27",
+   "display_name": "conda_python3",
    "language": "python",
-   "name": "conda_chainer_p27"
+   "name": "conda_python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
@@ -189,7 +189,7 @@
    "outputs": [],
    "source": [
     "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
-    "container = get_image_uri(boto3.Session(region_name=region).region_name, 'xgboost')"
+    "container = get_image_uri(region, 'xgboost')"
    ]
   },
   {

--- a/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
@@ -565,21 +565,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "conda_chainer_p27",
    "language": "python",
-   "name": "python3"
+   "name": "conda_chainer_p27"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,

--- a/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
@@ -535,6 +535,13 @@
    "source": [
     "client.delete_endpoint(EndpointName=endpoint_name)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
@@ -122,7 +122,7 @@
     "    tests_file.close()\n",
     "\n",
     "def write_to_s3(fobj, bucket, key):\n",
-    "    return boto3.Session().resource('s3').Bucket(bucket).Object(key).upload_fileobj(fobj)\n",
+    "    return boto3.Session(region_name=region).resource('s3').Bucket(bucket).Object(key).upload_fileobj(fobj)\n",
     "\n",
     "def upload_to_s3(bucket, channel, filename):\n",
     "    fobj=open(filename, 'rb')\n",
@@ -189,7 +189,7 @@
    "outputs": [],
    "source": [
     "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
-    "container = get_image_uri(boto3.Session().region_name, 'xgboost')"
+    "container = get_image_uri(boto3.Session(region_name=region).region_name, 'xgboost')"
    ]
   },
   {
@@ -267,7 +267,7 @@
     "}\n",
     "\n",
     "\n",
-    "client = boto3.client('sagemaker')\n",
+    "client = boto3.client('sagemaker', region_name=region)\n",
     "client.create_training_job(**create_training_params)\n",
     "\n",
     "import time\n",
@@ -308,7 +308,6 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "import boto3\n",
     "from time import gmtime, strftime\n",
     "\n",
     "model_name=job_name + '-model'\n",
@@ -421,7 +420,7 @@
    },
    "outputs": [],
    "source": [
-    "runtime_client = boto3.client('runtime.sagemaker')"
+    "runtime_client = boto3.client('runtime.sagemaker', region_name=region)"
    ]
   },
   {
@@ -566,9 +565,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -580,7 +579,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/introduction_to_amazon_algorithms/xgboost_mnist/xgboost_mnist.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_mnist/xgboost_mnist.ipynb
@@ -49,7 +49,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "isConfigCell": true
    },
    "outputs": [],
@@ -67,8 +66,10 @@
     "role = get_execution_role()\n",
     "\n",
     "region = boto3.Session().region_name\n",
+    "region='eu-west-1'\n",
+    "bucket='jasbarto-ml-ireland-bucket'\n",
     "\n",
-    "bucket='<bucket-name>' # put your s3 bucket name here, and create s3 bucket\n",
+    "#bucket='<bucket-name>' # put your s3 bucket name here, and create s3 bucket\n",
     "prefix = 'sagemaker/DEMO-xgboost-multiclass-classification'\n",
     "# customize to your bucket where you have stored the data\n",
     "bucket_path = 'https://s3-{}.amazonaws.com/{}'.format(region,bucket)"
@@ -86,9 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -113,9 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -183,9 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -207,9 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
@@ -219,9 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Ensure that the train and validation data folders generated above are reflected in the \"InputDataConfig\" parameter below.\n",
@@ -294,9 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#single machine job params\n",
@@ -321,9 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#distributed job params\n",
@@ -352,9 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -385,9 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print('Single Machine:', sm.describe_training_job(TrainingJobName=single_machine_job_name)['TrainingJobStatus'])\n",
@@ -408,9 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -448,9 +429,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from time import gmtime, strftime\n",
@@ -480,9 +459,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -520,9 +497,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "runtime_client = boto3.client('runtime.sagemaker', region_name=region)"
@@ -538,9 +513,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "download_from_s3('test', 0, 'mnist.local.test') # reading the first part file within test"
@@ -556,9 +529,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!head -1 mnist.local.test > mnist.single.test"
@@ -567,9 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -598,9 +567,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import sys\n",
@@ -633,7 +600,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -662,9 +628,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "preds[0:10]"
@@ -680,9 +644,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "labels[0:10]"
@@ -698,9 +660,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy\n",
@@ -729,9 +689,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -766,13 +724,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sm.delete_endpoint(EndpointName=endpoint_name)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/introduction_to_amazon_algorithms/xgboost_mnist/xgboost_mnist.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_mnist/xgboost_mnist.ipynb
@@ -133,7 +133,7 @@
     "\n",
     "\n",
     "def write_to_s3(fobj, bucket, key):\n",
-    "    return boto3.Session().resource('s3').Bucket(bucket).Object(key).upload_fileobj(fobj)\n",
+    "    return boto3.Session(region_name=region).resource('s3').Bucket(bucket).Object(key).upload_fileobj(fobj)\n",
     "\n",
     "def get_dataset():\n",
     "  import pickle\n",
@@ -162,7 +162,7 @@
     "    key = \"{}/{}/examples{}\".format(prefix,partition_name, number)\n",
     "    url = 's3n://{}/{}'.format(bucket, key)\n",
     "    print('Reading from {}'.format(url))\n",
-    "    s3 = boto3.resource('s3')\n",
+    "    s3 = boto3.resource('s3', region_name = region)\n",
     "    s3.Bucket(bucket).download_file(key, filename)\n",
     "    try:\n",
     "        s3.Bucket(bucket).download_file(key, 'mnist.local.test')\n",
@@ -213,7 +213,7 @@
    "outputs": [],
    "source": [
     "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
-    "container = get_image_uri(boto3.Session().region_name, 'xgboost')"
+    "container = get_image_uri(region, 'xgboost')"
    ]
   },
   {
@@ -359,8 +359,7 @@
    "source": [
     "%%time\n",
     "\n",
-    "region = boto3.Session().region_name\n",
-    "sm = boto3.Session().client('sagemaker')\n",
+    "sm = boto3.Session(region_name=region).client('sagemaker')\n",
     "\n",
     "sm.create_training_job(**single_machine_job_params)\n",
     "sm.create_training_job(**distributed_job_params)\n",
@@ -526,7 +525,7 @@
    },
    "outputs": [],
    "source": [
-    "runtime_client = boto3.client('runtime.sagemaker')"
+    "runtime_client = boto3.client('runtime.sagemaker', region_name=region)"
    ]
   },
   {
@@ -779,9 +778,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -793,7 +792,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.6"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },

--- a/introduction_to_amazon_algorithms/xgboost_mnist/xgboost_mnist.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_mnist/xgboost_mnist.ipynb
@@ -778,9 +778,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "conda_python3",
    "language": "python",
-   "name": "python3"
+   "name": "conda_python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -792,7 +792,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.5"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },


### PR DESCRIPTION
This pull request makes changes to the MNIST and Abalone XGBoost notebooks.  In both notebooks there is a variable named `region` in the initial code block.  The impression customers get is that this controls which region the notebook will work with but in many subsequent code blocks `region` is redefined or ignored as S3 and SageMaker clients are instantiated.  

This update modifies both notebooks to adopt the initial definition of `region` through every line of code.  This will prevent customers from getting confusing error messages about regionality when they modify the `region` value.