### PR TITLE
Use GPU instance for Neo Image Classification

### DIFF
--- a/introduction_to_amazon_algorithms/imageclassification_caltech/Image-classification-fulltraining-highlevel-neo.ipynb
+++ b/introduction_to_amazon_algorithms/imageclassification_caltech/Image-classification-fulltraining-highlevel-neo.ipynb
@@ -379,7 +379,7 @@
    "outputs": [],
    "source": [
     "output_path = '/'.join(ic.output_path.split('/')[:-1])\n",
-    "optimized_ic = ic.compile_model(target_instance_family='ml_c5', \n",
+    "optimized_ic = ic.compile_model(target_instance_family='ml_p3', \n",    # Use GPU instance
     "                                input_shape={'data':[1, 3, 224, 224]},  # Batch size 1, 3 channels, 224x224 Images.\n",
     "                                output_path=output_path,\n",
     "                                framework='mxnet', framework_version='1.2.1')"
@@ -414,7 +414,7 @@
    "outputs": [],
    "source": [
     "optimized_ic_classifier = optimized_ic.deploy(initial_instance_count = 1,\n",
-    "                                              instance_type = 'ml.c5.4xlarge')"
+    "                                              instance_type = 'ml.p3.xlarge')"
    ]
   },
   {


### PR DESCRIPTION
To match the behavior of SageMaker Image Classification, Neo should use GPU instance for Image Classification.

cc @wweic 