### PR TITLE
Add FAQ link to reinforcement learning folder

### DIFF
--- a/reinforcement_learning/README.md
+++ b/reinforcement_learning/README.md
@@ -2,3 +2,5 @@
 
 These examples demonstrate how to train reinforcement learning models on SageMaker.
 
+## FAQ
+https://github.com/awslabs/amazon-sagemaker-examples#faq 

--- a/reinforcement_learning/rl_hvac_coach_energyplus/README.md
+++ b/reinforcement_learning/rl_hvac_coach_energyplus/README.md
@@ -32,7 +32,7 @@ EnergyPlus: 8.8.0 (https://github.com/NREL/EnergyPlus/releases/tag/v8.8.0)
 4. Afram, Abdul, and Farrokh Janabi-Sharifi. "Theory and applications of HVAC control systems–A review of model predictive control (MPC)." Building and Environment 72 (2014): 343-355.
 5. Fong, Kwong Fai, Victor Ian Hanby, and Tin-Tai Chow. "System optimization for HVAC energy management using the robust evolutionary algorithm." Applied Thermal Engineering 29, no. 11-12 (2009): 2327-2334.
 6. Balaji, Bharathan, Jian Xu, Anthony Nwokafor, Rajesh Gupta, and Yuvraj Agarwal. "Sentinel: Occupancy based HVAC actuation using existing WiFi infrastructure within commercial buildings." In Proceedings of the 11th ACM Conference on Embedded Networked Sensor Systems, p. 17. ACM, 2013.
-7. Wei, Tianshu, Yanzhi Wang, and Qi Zhu. "Deep reinforcement learning for building hvac control." In Proceedings of the 54th Annual Design Automation Conference 2017, p. 22. ACM, 2017.
+7. Wei, Tianshu, Yanzhi Wang, and Qi Zhu. "Deep reinforcement learning for building HVAC control." In Proceedings of the 54th Annual Design Automation Conference 2017, p. 22. ACM, 2017.
 8. Zhang, Zhiang, and Khee Poh Lam. "Practical implementation and evaluation of deep reinforcement learning control for a radiant heating system." In Proceedings of the 5th Conference on Systems for Built Environments, pp. 148-157. ACM, 2018.
 
 

--- a/reinforcement_learning/rl_hvac_coach_energyplus/README.md
+++ b/reinforcement_learning/rl_hvac_coach_energyplus/README.md
@@ -6,7 +6,7 @@ HVAC stands for Heating, Ventilation and Air Conditioning and is responsible for
 
 In a modern building, data such as weather, occupancy and equipment use are collected routinely and can be used to optimize HVAC energy use. Reinforcement Learning (RL) is a good fit as it can learn patterns in the data and identify strategies to control the system so as to reduce energy. Several recent research efforts have shown that RL can reduce HVAC energy consumption by 15-20% [7, 8].
 
-As training an RL algorithm in a real HVAC system can take time to converge as well as potentially lead to hazardous settings as the agent explores its state space, we turn to a simulator to train the agent. EnergyPlus (https://energyplus.net/) is an open source, state of the art HVAC simulator from the US Department of Energy. We use a simple example with this simulator to showcase how we can train an RL model easily with Amazon SageMaker.
+As training an RL algorithm in a real HVAC system can take time to converge as well as potentially lead to hazardous settings as the agent explores its state space, we turn to a simulator to train the agent. [EnergyPlus](https://energyplus.net/) is an open source, state of the art HVAC simulator from the US Department of Energy. We use a simple example with this simulator to showcase how we can train an RL model easily with Amazon SageMaker.
 
 ## Contents
 

--- a/reinforcement_learning/rl_hvac_coach_energyplus/README.md
+++ b/reinforcement_learning/rl_hvac_coach_energyplus/README.md
@@ -2,9 +2,9 @@
 
 ## What is HVAC and EnergyPlus?
 
-HVAC stands for Heating, Ventilation and Air Conditioning and is responsible for keeping us warm and comfortable indoors. HVAC takes up a whopping 50% of the energy in a building and accounts for 40% of energy use in the US, and several control system optimizations have been proposed to reduce this energy use while ensuring thermal comfort.
+HVAC stands for Heating, Ventilation and Air Conditioning and is responsible for keeping us warm and comfortable indoors. HVAC takes up a whopping 50% of the energy in a building [1, 2] and accounts for 10% of global electricity use [3], and several control system optimizations have been proposed to reduce this energy use while ensuring thermal comfort [4, 5, 6].
 
-In a modern building, data such as weather, occupancy and equipment use are collected routinely and can be used to optimize HVAC energy use. Reinforcement Learning (RL) is a good fit as it can learn patterns in the data and identify strategies to control the system so as to reduce energy. Several recent research efforts have shown that RL can reduce HVAC energy consumption by 15-20% [1, 2].
+In a modern building, data such as weather, occupancy and equipment use are collected routinely and can be used to optimize HVAC energy use. Reinforcement Learning (RL) is a good fit as it can learn patterns in the data and identify strategies to control the system so as to reduce energy. Several recent research efforts have shown that RL can reduce HVAC energy consumption by 15-20% [7, 8].
 
 As training an RL algorithm in a real HVAC system can take time to converge as well as potentially lead to hazardous settings as the agent explores its state space, we turn to a simulator to train the agent. EnergyPlus (https://energyplus.net/) is an open source, state of the art HVAC simulator from the US Department of Energy. We use a simple example with this simulator to showcase how we can train an RL model easily with Amazon SageMaker.
 
@@ -23,3 +23,16 @@ As training an RL algorithm in a real HVAC system can take time to converge as w
 
 Python: 3.6.4
 EnergyPlus: 8.8.0 (https://github.com/NREL/EnergyPlus/releases/tag/v8.8.0)
+
+## References
+
+1. Residential Energy Consumption Survey - https://www.eia.gov/consumption/residential/
+2. Energy Use in Commercial Buildings - https://www.eia.gov/energyexplained/index.php?page=us\_energy\_commercial  
+3. The Future of Cooling - https://www.iea.org/futureofcooling/ 
+4. Afram, Abdul, and Farrokh Janabi-Sharifi. "Theory and applications of HVAC control systems–A review of model predictive control (MPC)." Building and Environment 72 (2014): 343-355.
+5. Fong, Kwong Fai, Victor Ian Hanby, and Tin-Tai Chow. "System optimization for HVAC energy management using the robust evolutionary algorithm." Applied Thermal Engineering 29, no. 11-12 (2009): 2327-2334.
+6. Balaji, Bharathan, Jian Xu, Anthony Nwokafor, Rajesh Gupta, and Yuvraj Agarwal. "Sentinel: occupancy based HVAC actuation using existing WiFi infrastructure within commercial buildings." In Proceedings of the 11th ACM Conference on Embedded Networked Sensor Systems, p. 17. ACM, 2013.
+7. Wei, Tianshu, Yanzhi Wang, and Qi Zhu. "Deep reinforcement learning for building hvac control." In Proceedings of the 54th Annual Design Automation Conference 2017, p. 22. ACM, 2017.
+8. Zhang, Zhiang, and Khee Poh Lam. "Practical implementation and evaluation of deep reinforcement learning control for a radiant heating system." In Proceedings of the 5th Conference on Systems for Built Environments, pp. 148-157. ACM, 2018.
+
+

--- a/reinforcement_learning/rl_hvac_coach_energyplus/README.md
+++ b/reinforcement_learning/rl_hvac_coach_energyplus/README.md
@@ -31,7 +31,7 @@ EnergyPlus: 8.8.0 (https://github.com/NREL/EnergyPlus/releases/tag/v8.8.0)
 3. The Future of Cooling - https://www.iea.org/futureofcooling/ 
 4. Afram, Abdul, and Farrokh Janabi-Sharifi. "Theory and applications of HVAC control systems–A review of model predictive control (MPC)." Building and Environment 72 (2014): 343-355.
 5. Fong, Kwong Fai, Victor Ian Hanby, and Tin-Tai Chow. "System optimization for HVAC energy management using the robust evolutionary algorithm." Applied Thermal Engineering 29, no. 11-12 (2009): 2327-2334.
-6. Balaji, Bharathan, Jian Xu, Anthony Nwokafor, Rajesh Gupta, and Yuvraj Agarwal. "Sentinel: occupancy based HVAC actuation using existing WiFi infrastructure within commercial buildings." In Proceedings of the 11th ACM Conference on Embedded Networked Sensor Systems, p. 17. ACM, 2013.
+6. Balaji, Bharathan, Jian Xu, Anthony Nwokafor, Rajesh Gupta, and Yuvraj Agarwal. "Sentinel: Occupancy based HVAC actuation using existing WiFi infrastructure within commercial buildings." In Proceedings of the 11th ACM Conference on Embedded Networked Sensor Systems, p. 17. ACM, 2013.
 7. Wei, Tianshu, Yanzhi Wang, and Qi Zhu. "Deep reinforcement learning for building hvac control." In Proceedings of the 54th Annual Design Automation Conference 2017, p. 22. ACM, 2017.
 8. Zhang, Zhiang, and Khee Poh Lam. "Practical implementation and evaluation of deep reinforcement learning control for a radiant heating system." In Proceedings of the 5th Conference on Systems for Built Environments, pp. 148-157. ACM, 2018.
 


### PR DESCRIPTION
Users navigating directly to the reinforcement learning folder do not tend to visit the FAQ listed at the bottom of the main README