### PR TITLE
Freeze framework mode TF notebooks to use 1.12

### DIFF
--- a/hyperparameter_tuning/tensorflow_mnist/hpo_tensorflow_mnist.ipynb
+++ b/hyperparameter_tuning/tensorflow_mnist/hpo_tensorflow_mnist.ipynb
@@ -176,7 +176,7 @@
    "source": [
     "estimator = TensorFlow(entry_point='mnist.py',\n",
     "                  role=role,\n",
-    "                  framework_version='1.11.0',\n",
+    "                  framework_version='1.12.0',\n",
     "                  training_steps=1000, \n",
     "                  evaluation_steps=100,\n",
     "                  train_instance_count=1,\n",

--- a/sagemaker-python-sdk/tensorflow_abalone_age_predictor_using_keras/tensorflow_abalone_age_predictor_using_keras.ipynb
+++ b/sagemaker-python-sdk/tensorflow_abalone_age_predictor_using_keras/tensorflow_abalone_age_predictor_using_keras.ipynb
@@ -461,7 +461,7 @@
     "\n",
     "abalone_estimator = TensorFlow(entry_point='abalone.py',\n",
     "                               role=role,\n",
-    "                               framework_version='1.11.0',\n",
+    "                               framework_version='1.12.0',\n",
     "                               training_steps= 100,                                  \n",
     "                               evaluation_steps= 100,\n",
     "                               hyperparameters={'learning_rate': 0.001},\n",

--- a/sagemaker-python-sdk/tensorflow_abalone_age_predictor_using_layers/tensorflow_abalone_age_predictor_using_layers.ipynb
+++ b/sagemaker-python-sdk/tensorflow_abalone_age_predictor_using_layers/tensorflow_abalone_age_predictor_using_layers.ipynb
@@ -506,7 +506,7 @@
     "\n",
     "abalone_estimator = TensorFlow(entry_point='abalone.py',\n",
     "                               role=role,\n",
-    "                               framework_version='1.11.0',\n",
+    "                               framework_version='1.12.0',\n",
     "                               training_steps= 100,                                  \n",
     "                               evaluation_steps= 100,\n",
     "                               hyperparameters={'learning_rate': 0.001},\n",

--- a/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_batch_transform_mnist.ipynb
+++ b/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_batch_transform_mnist.ipynb
@@ -117,7 +117,7 @@
     "\n",
     "mnist_estimator = TensorFlow(entry_point='mnist.py',\n",
     "                             role=role,\n",
-    "                             framework_version='1.11.0',\n",
+    "                             framework_version='1.12.0',\n",
     "                             training_steps=1000, \n",
     "                             evaluation_steps=100,\n",
     "                             train_instance_count=2,\n",

--- a/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_distributed_mnist.ipynb
+++ b/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_distributed_mnist.ipynb
@@ -149,7 +149,7 @@
     "\n",
     "mnist_estimator = TensorFlow(entry_point='mnist.py',\n",
     "                             role=role,\n",
-    "                             framework_version='1.11.0',\n",
+    "                             framework_version='1.12.0',\n",
     "                             training_steps=1000, \n",
     "                             evaluation_steps=100,\n",
     "                             train_instance_count=2,\n",
@@ -218,7 +218,7 @@
     "    print(\"========================================\")\n",
     "    label = np.argmax(mnist.test.labels[i])\n",
     "    print(\"label is {}\".format(label))\n",
-    "    prediction = predict_response['outputs']['classes']['int64Val'][0]\n",
+    "    prediction = predict_response['outputs']['classes']['int64_val'][0]\n",
     "    print(\"prediction is {}\".format(prediction))"
    ]
   },

--- a/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_local_mode_mnist.ipynb
+++ b/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_local_mode_mnist.ipynb
@@ -165,7 +165,7 @@
     "\n",
     "mnist_estimator = TensorFlow(entry_point='mnist.py',\n",
     "                             role=role,\n",
-    "                             framework_version='1.11.0',\n",
+    "                             framework_version='1.12.0',\n",
     "                             training_steps=10, \n",
     "                             evaluation_steps=10,\n",
     "                             train_instance_count=2,\n",
@@ -230,7 +230,7 @@
     "    print(\"========================================\")\n",
     "    label = np.argmax(mnist.test.labels[i])\n",
     "    print(\"label is {}\".format(label))\n",
-    "    prediction = predict_response['outputs']['classes']['int64Val'][0]\n",
+    "    prediction = predict_response['outputs']['classes']['int64_val'][0]\n",
     "    print(\"prediction is {}\".format(prediction))"
    ]
   },

--- a/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/tensorflow_iris_dnn_classifier_using_estimators.ipynb
+++ b/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/tensorflow_iris_dnn_classifier_using_estimators.ipynb
@@ -305,7 +305,7 @@
     "\n",
     "iris_estimator = TensorFlow(entry_point='iris_dnn_classifier.py',\n",
     "                            role=role,\n",
-    "                            framework_version='1.11.0',\n",
+    "                            framework_version='1.12.0',\n",
     "                            output_path=model_artifacts_location,\n",
     "                            code_location=custom_code_upload_location,\n",
     "                            train_instance_count=1,\n",

--- a/sagemaker-python-sdk/tensorflow_keras_cifar10/tensorflow_keras_CIFAR10.ipynb
+++ b/sagemaker-python-sdk/tensorflow_keras_cifar10/tensorflow_keras_CIFAR10.ipynb
@@ -222,7 +222,7 @@
     "\n",
     "estimator = TensorFlow(entry_point='cifar10_cnn.py',\n",
     "                       role=role,\n",
-    "                       framework_version='1.11.0',\n",
+    "                       framework_version='1.12.0',\n",
     "                       hyperparameters={'learning_rate': 1e-4, 'decay':1e-6},\n",
     "                       training_steps=1000, evaluation_steps=100,\n",
     "                       train_instance_count=1, train_instance_type='ml.c4.xlarge')\n",

--- a/sagemaker-python-sdk/tensorflow_pipemode_example/tensorflow_pipemode_example.ipynb
+++ b/sagemaker-python-sdk/tensorflow_pipemode_example/tensorflow_pipemode_example.ipynb
@@ -139,7 +139,7 @@
     "\n",
     "tensorflow = TensorFlow(entry_point='pipemode.py',\n",
     "                        role=role,\n",
-    "                        framework_version='1.11.0',\n",
+    "                        framework_version='1.12.0',\n",
     "                        input_mode='Pipe',\n",
     "                        output_path=model_artifacts_location,\n",
     "                        code_location=custom_code_upload_location,\n",

--- a/sagemaker-python-sdk/tensorflow_resnet_cifar10_with_tensorboard/tensorflow_resnet_cifar10_with_tensorboard.ipynb
+++ b/sagemaker-python-sdk/tensorflow_resnet_cifar10_with_tensorboard/tensorflow_resnet_cifar10_with_tensorboard.ipynb
@@ -118,7 +118,7 @@
     "estimator = TensorFlow(entry_point='resnet_cifar_10.py',\n",
     "                       source_dir=source_dir,\n",
     "                       role=role,\n",
-    "                       framework_version='1.11.0',\n",
+    "                       framework_version='1.12.0',\n",
     "                       hyperparameters={'throttle_secs': 30},\n",
     "                       training_steps=1000, evaluation_steps=100,\n",
     "                       train_instance_count=2, train_instance_type='ml.c4.xlarge', \n",

--- a/sagemaker-python-sdk/tensorflow_serving_container/tensorflow_serving_container.ipynb
+++ b/sagemaker-python-sdk/tensorflow_serving_container/tensorflow_serving_container.ipynb
@@ -191,7 +191,7 @@
     "# predictable model.\n",
     "env = {'SAGEMAKER_TFS_DEFAULT_MODEL_NAME': 'mobilenet_v2_140_224'}\n",
     "\n",
-    "model = Model(model_data=model_data, role=sagemaker_role, framework_version=1.11, env=env)\n",
+    "model = Model(model_data=model_data, role=sagemaker_role, framework_version=1.12, env=env)\n",
     "predictor = model.deploy(initial_instance_count=1, instance_type='ml.c5.xlarge')"
    ]
   },


### PR DESCRIPTION
1. Freeze framework mode TF related notebooks to use TF 1.12.0
2. Update the key name in prediction response from 'int64Val' to 'int64_val' in distributed mnist notebooks