### PR TITLE
Update Coach to 0.11 for DeepRacer and ObjectTracker sample application

### DIFF
--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/rl_deepracer_coach_robomaker.ipynb
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/rl_deepracer_coach_robomaker.ipynb
@@ -423,7 +423,7 @@
     "                        source_dir='src',\n",
     "                        dependencies=[\"common/sagemaker_rl\"],\n",
     "                        toolkit=RLToolkit.COACH,\n",
-    "                        toolkit_version='0.10.1',\n",
+    "                        toolkit_version='0.11.0',\n",
     "                        framework=RLFramework.TENSORFLOW,\n",
     "                        role=role,\n",
     "                        train_instance_type=instance_type,\n",
@@ -506,7 +506,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation_application_bundle_location = \"https://s3-us-west-2.amazonaws.com/robomaker-applications-us-west-2-11d8d0439f6a/deep-racer/deep-racer-1.0.57.0.1.0.66.0/simulation_ws.tar.gz\"\n",
+    "simulation_application_bundle_location = \"https://s3-us-west-2.amazonaws.com/robomaker-applications-us-west-2-11d8d0439f6a/deep-racer/deep-racer-1.0.74.0.1.0.82.0/simulation_ws.tar.gz\"\n",
     "\n",
     "!wget {simulation_application_bundle_location}\n",
     "!aws s3 cp simulation_ws.tar.gz s3://{s3_bucket}/{bundle_s3_key}\n",

--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/robomaker/presets/deepracer.py
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/src/robomaker/presets/deepracer.py
@@ -11,6 +11,7 @@ from rl_coach.filters.filter import NoInputFilter, NoOutputFilter, InputFilter
 from rl_coach.filters.observation.observation_stacking_filter import ObservationStackingFilter
 from rl_coach.filters.observation.observation_rgb_to_y_filter import ObservationRGBToYFilter
 from rl_coach.filters.observation.observation_to_uint8_filter import ObservationToUInt8Filter
+from rl_coach.memories.memory import MemoryGranularity
 
 ####################
 # Graph Scheduling #
@@ -26,6 +27,8 @@ schedule_params.heatup_steps = EnvironmentSteps(0)
 # Agent #
 #########
 agent_params = ClippedPPOAgentParameters()
+
+agent_params.memory.max_size = (MemoryGranularity.Transitions, 10**5)
 
 agent_params.network_wrappers['main'].learning_rate = 0.0003
 agent_params.network_wrappers['main'].input_embedders_parameters['observation'].activation_function = 'relu'

--- a/reinforcement_learning/rl_objecttracker_robomaker_coach_gazebo/rl_objecttracker_coach_robomaker.ipynb
+++ b/reinforcement_learning/rl_objecttracker_robomaker_coach_gazebo/rl_objecttracker_coach_robomaker.ipynb
@@ -375,7 +375,7 @@
     "                        source_dir='src',\n",
     "                        dependencies=[\"common/sagemaker_rl\"],\n",
     "                        toolkit=RLToolkit.COACH,\n",
-    "                        toolkit_version='0.10.1',\n",
+    "                        toolkit_version='0.11.0',\n",
     "                        framework=RLFramework.TENSORFLOW,\n",
     "                        role=role,\n",
     "                        train_instance_type=instance_type,\n",
@@ -447,7 +447,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation_application_bundle_location = \"https://s3-us-west-2.amazonaws.com/robomaker-applications-us-west-2-11d8d0439f6a/object-tracker/object-tracker-1.0.57.0.1.0.82.0/simulation_ws.tar.gz\"\n",
+    "simulation_application_bundle_location = \"https://s3-us-west-2.amazonaws.com/robomaker-applications-us-west-2-11d8d0439f6a/object-tracker/object-tracker-1.0.74.0.1.0.105.0/simulation_ws.tar.gz\"\n",
     "\n",
     "!wget {simulation_application_bundle_location}\n",
     "!aws s3 cp simulation_ws.tar.gz s3://{s3_bucket}/{bundle_s3_key}\n",

--- a/reinforcement_learning/rl_objecttracker_robomaker_coach_gazebo/src/robomaker/presets/object_tracker.py
+++ b/reinforcement_learning/rl_objecttracker_robomaker_coach_gazebo/src/robomaker/presets/object_tracker.py
@@ -5,6 +5,7 @@ from rl_coach.environments.gym_environment import GymVectorEnvironment
 from rl_coach.graph_managers.basic_rl_graph_manager import BasicRLGraphManager
 from rl_coach.graph_managers.graph_manager import ScheduleParameters
 from rl_coach.schedules import LinearSchedule
+from rl_coach.memories.memory import MemoryGranularity
 
 from rl_coach.exploration_policies.categorical import CategoricalParameters
 from rl_coach.filters.filter import NoInputFilter, NoOutputFilter, InputFilter
@@ -26,6 +27,8 @@ schedule_params.heatup_steps = EnvironmentSteps(0)
 # Agent #
 #########
 agent_params = ClippedPPOAgentParameters()
+
+agent_params.memory.max_size = (MemoryGranularity.Transitions, 10**5)
 
 agent_params.network_wrappers['main'].learning_rate = 0.0003
 agent_params.network_wrappers['main'].input_embedders_parameters['observation'].activation_function = 'relu'


### PR DESCRIPTION
Changes include
- Using Coach Toolkit version 0.11.0
- Reducing the transition memory to 10^5 to avoid out of memory.

Testing
- Tested on a fresh instance of notebook