### PR TITLE
update EI TF version to 1.12

### DIFF
--- a/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/tensorflow_iris_dnn_classifier_using_estimators_elastic_inference.ipynb
+++ b/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/tensorflow_iris_dnn_classifier_using_estimators_elastic_inference.ipynb
@@ -317,7 +317,7 @@
     "\n",
     "iris_estimator = TensorFlow(entry_point='iris_dnn_classifier.py',\n",
     "                            role=role,\n",
-    "                            framework_version='1.11',\n",
+    "                            framework_version='1.12',\n",
     "                            output_path=model_artifacts_location,\n",
     "                            code_location=custom_code_upload_location,\n",
     "                            train_instance_count=1,\n",

--- a/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/tensorflow_iris_dnn_classifier_using_estimators_elastic_inference_local.ipynb
+++ b/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/tensorflow_iris_dnn_classifier_using_estimators_elastic_inference_local.ipynb
@@ -342,7 +342,7 @@
     "\n",
     "iris_estimator = TensorFlow(entry_point='iris_dnn_classifier.py',\n",
     "                            role=role,\n",
-    "                            framework_version='1.11',\n",
+    "                            framework_version='1.12',\n",
     "                            train_instance_count=1,\n",
     "                            train_instance_type='local',\n",
     "                            training_steps=1000,\n",

--- a/sagemaker-python-sdk/tensorflow_using_elastic_inference_with_your_own_model/tensorflow_pretrained_model_elastic_inference.ipynb
+++ b/sagemaker-python-sdk/tensorflow_using_elastic_inference_with_your_own_model/tensorflow_pretrained_model_elastic_inference.ipynb
@@ -107,7 +107,7 @@
     "tensorflow_model = TensorFlowModel(model_data=saved_model,\n",
     "                                   entry_point='entry.py',\n",
     "                                   role=role,\n",
-    "                                   framework_version='1.11')"
+    "                                   framework_version='1.12')"
    ]
   },
   {


### PR DESCRIPTION
Update version to 1.12 for TensorFlow Elastic Inference Examples.

Waiting on https://github.com/aws/sagemaker-python-sdk/pull/597 to be merged.