### PR TITLE
Add Batch Transform sample to scikit Bring your own algorithm notebook

### DIFF
--- a/advanced_functionality/scikit_bring_your_own/container/Dockerfile
+++ b/advanced_functionality/scikit_bring_your_own/container/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
 # a significant amount of space. These optimizations save a fair amount of space in the
 # image, which reduces start up time.
 RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py && \
-    pip install numpy==1.14.5 scipy scikit-learn pandas flask gevent gunicorn && \
+    pip install numpy==1.15.0 scipy scikit-learn pandas flask gevent gunicorn && \
         (cd /usr/local/lib/python2.7/dist-packages/scipy/.libs; rm *; ln ../../numpy/.libs/* .) && \
         rm -rf /root/.cache
 

--- a/advanced_functionality/scikit_bring_your_own/container/decision_trees/nginx.conf
+++ b/advanced_functionality/scikit_bring_your_own/container/decision_trees/nginx.conf
@@ -23,6 +23,7 @@ http {
     client_max_body_size 5m;
 
     keepalive_timeout 5;
+    proxy_read_timeout 300s;
 
     location ~ ^/(ping|invocations) {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/advanced_functionality/scikit_bring_your_own/container/decision_trees/nginx.conf
+++ b/advanced_functionality/scikit_bring_your_own/container/decision_trees/nginx.conf
@@ -23,7 +23,7 @@ http {
     client_max_body_size 5m;
 
     keepalive_timeout 5;
-    proxy_read_timeout 300s;
+    proxy_read_timeout 1200s;
 
     location ~ ^/(ping|invocations) {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/advanced_functionality/scikit_bring_your_own/container/decision_trees/predictor.py
+++ b/advanced_functionality/scikit_bring_your_own/container/decision_trees/predictor.py
@@ -72,6 +72,9 @@ def transformation():
 
     print('Invoked with {} records'.format(data.shape[0]))
 
+    # Drop first column, since sample notebook uses training data to show case predictions
+    data.drop(data.columns[[0]],axis=1,inplace=True)
+
     # Do the prediction
     predictions = ScoringService.predict(data)
 

--- a/advanced_functionality/scikit_bring_your_own/scikit_bring_your_own.ipynb
+++ b/advanced_functionality/scikit_bring_your_own/scikit_bring_your_own.ipynb
@@ -11,11 +11,11 @@
     "By packaging an algorithm in a container, you can bring almost any code to the Amazon SageMaker environment, regardless of programming language, environment, framework, or dependencies. \n",
     "\n",
     "1. [Building your own algorithm container](#Building-your-own-algorithm-container)\n",
-    "  1. [When should I build my own algorithm container?](#When-should-I-build-my-own-algorithm-container?)\n",
+    "  1. [When should I build my own algorithm container?](#When-should-I-build-my-own-algorithm-container%3F)\n",
     "  1. [Permissions](#Permissions)\n",
     "  1. [The example](#The-example)\n",
     "  1. [The presentation](#The-presentation)\n",
-    "1. [Part 1: Packaging and Uploading your Algorithm for use with Amazon SageMaker](#Part-1:-Packaging-and-Uploading-your-Algorithm-for-use-with-Amazon-SageMaker)\n",
+    "1. [Part 1: Packaging and Uploading your Algorithm for use with Amazon SageMaker](#Part-1%3A-Packaging-and-Uploading-your-Algorithm-for-use-with-Amazon-SageMaker)\n",
     "    1. [An overview of Docker](#An-overview-of-Docker)\n",
     "    1. [How Amazon SageMaker runs your Docker container](#How-Amazon-SageMaker-runs-your-Docker-container)\n",
     "      1. [Running your container during training](#Running-your-container-during-training)\n",
@@ -26,14 +26,18 @@
     "    1. [The Dockerfile](#The-Dockerfile)\n",
     "    1. [Building and registering the container](#Building-and-registering-the-container)\n",
     "  1. [Testing your algorithm on your local machine or on an Amazon SageMaker notebook instance](#Testing-your-algorithm-on-your-local-machine-or-on-an-Amazon-SageMaker-notebook-instance)\n",
-    "1. [Part 2: Training and Hosting your Algorithm in Amazon SageMaker](#Part-2:-Training-and-Hosting-your-Algorithm-in-Amazon-SageMaker)\n",
+    "1. [Part 2: Using your Algorithm in Amazon SageMaker](#Part-2%3A-Using-your-Algorithm-in-Amazon-SageMaker)\n",
     "  1. [Set up the environment](#Set-up-the-environment)\n",
     "  1. [Create the session](#Create-the-session)\n",
     "  1. [Upload the data for training](#Upload-the-data-for-training)\n",
     "  1. [Create an estimator and fit the model](#Create-an-estimator-and-fit-the-model)\n",
-    "  1. [Deploy the model](#Deploy-the-model)\n",
-    "  1. [Choose some data and use it for a prediction](#Choose-some-data-and-use-it-for-a-prediction)\n",
-    "  1. [Optional cleanup](#Optional-cleanup)  \n",
+    "  1. [Hosting your model](#Hosting-your-model)\n",
+    "    1. [Deploy the model](#Deploy-the-model)\n",
+    "    2. [Choose some data and use it for a prediction](#Choose-some-data-and-use-it-for-a-prediction)\n",
+    "    3. [Optional cleanup](#Optional-cleanup)\n",
+    "  1. [Run Batch Transform Job](#Run-Batch-Transform-Job)\n",
+    "    1. [Create a Transform Job](#Create-a-Transform-Job)\n",
+    "    2. [View Output](#View-Output)\n",
     "\n",
     "_or_ I'm impatient, just [let me see the code](#The-Dockerfile)!\n",
     "\n",
@@ -241,7 +245,7 @@
     "%%sh\n",
     "\n",
     "# The name of our algorithm\n",
-    "algorithm_name=decision-trees-sample\n",
+    "algorithm_name=sagemaker-decision-trees\n",
     "\n",
     "cd container\n",
     "\n",
@@ -257,7 +261,6 @@
     "fullname=\"${account}.dkr.ecr.${region}.amazonaws.com/${algorithm_name}:latest\"\n",
     "\n",
     "# If the repository doesn't exist in ECR, create it.\n",
-    "\n",
     "aws ecr describe-repositories --repository-names \"${algorithm_name}\" > /dev/null 2>&1\n",
     "\n",
     "if [ $? -ne 0 ]\n",
@@ -298,9 +301,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Part 2: Training and Hosting your Algorithm in Amazon SageMaker\n",
+    "# Part 2: Using your Algorithm in Amazon SageMaker\n",
     "\n",
-    "Once you have your container packaged, you can use it to train and serve models. Let's do that with the algorithm we made above.\n",
+    "Once you have your container packaged, you can use it to train models and use the model for hosting or batch transforms. Let's do that with the algorithm we made above.\n",
     "\n",
     "## Set up the environment\n",
     "\n",
@@ -401,7 +404,7 @@
    "source": [
     "account = sess.boto_session.client('sts').get_caller_identity()['Account']\n",
     "region = sess.boto_session.region_name\n",
-    "image = '{}.dkr.ecr.{}.amazonaws.com/decision-trees-sample:latest'.format(account, region)\n",
+    "image = '{}.dkr.ecr.{}.amazonaws.com/sagemaker-decision-trees:latest'.format(account, region)\n",
     "\n",
     "tree = sage.estimator.Estimator(image,\n",
     "                       role, 1, 'ml.c4.2xlarge',\n",
@@ -415,7 +418,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deploy the model\n",
+    "## Hosting your model\n",
+    "One can use trained model to get real time predictions using HTTP endpoint. Following steps walk you through the process."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Deploy the model\n",
     "\n",
     "Deploying the model to SageMaker hosting just requires a `deploy` call on the fitted model. This call takes an instance count, instance type, and optionally serializer and deserializer functions. These are used when the resulting predictor is created on the endpoint."
    ]
@@ -434,7 +445,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Choose some data and use it for a prediction\n",
+    "### Choose some data and use it for a prediction\n",
     "\n",
     "In order to do some predictions, we'll extract some of the data we used for training and do predictions against it. This is, of course, bad statistical practice, but a good way to see how the mechanism works."
    ]
@@ -442,9 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "shape=pd.read_csv(\"data/iris.csv\", header=None)\n",
@@ -455,9 +464,7 @@
     "b = [40+i for i in range(10)]\n",
     "indices = [i+j for i,j in itertools.product(a,b)]\n",
     "\n",
-    "test_data=shape.iloc[indices[:-1]]\n",
-    "test_X=test_data.iloc[:,1:]\n",
-    "test_y=test_data.iloc[:,0]"
+    "test_data=shape.iloc[indices[:-1]]"
    ]
   },
   {
@@ -473,15 +480,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(predictor.predict(test_X.values).decode('utf-8'))"
+    "print(predictor.predict(test_data.values).decode('utf-8'))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Optional cleanup\n",
-    "\n",
+    "### Optional cleanup\n",
     "When you're done with the endpoint, you'll want to clean it up."
    ]
   },
@@ -492,6 +498,88 @@
    "outputs": [],
    "source": [
     "sess.delete_endpoint(predictor.endpoint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run Batch Transform Job\n",
+    "One can use trained model to get inference on large data sets by using [Amazon SageMaker Batch Transform](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-batch.html). A Batch Transform Job takes your input data S3 location and publishes prediction result to specified S3 output folder. Similar to hosting, lets extract inferences for training data to demo Batch Transform mechanism."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create a Transform Job\n",
+    "We'll create an `Transformer` that defines how to use the container to get inference results on a data set. This includes the configuration we need to invoke SageMaker Batch transform:\n",
+    "\n",
+    "* The __instance count__ which is the number of machines to use to extract inferences\n",
+    "* The __instance type__ which is the type of machine to use to extract inferences\n",
+    "* The __output path__ determines where the inference results will be written"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transform_output_folder = \"batch-transform-output\"\n",
+    "output_path=\"s3://{}/{}\".format(sess.default_bucket(), transform_output_folder)\n",
+    "\n",
+    "transformer = tree.transformer(instance_count=1,\n",
+    "                               instance_type='ml.m4.xlarge',\n",
+    "                               output_path=output_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use tranform() on the transfomer to get inference results against the data that we uploaded above. We provide below options when invoking transformer. \n",
+    "* The __data_location__ which is the location of input data\n",
+    "* The __content_type__ which is the content type set when making HTTP request to container to get prediction\n",
+    "* The __split_type__ which is the delimiter used for splitting input data "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transformer.transform(data_location, content_type='text/csv', split_type='Line')\n",
+    "transformer.wait()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For more configuration options and details, please visit [CreateTransformJob API](https://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateTransformJob.html) page"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### View Output\n",
+    "Lets read results of above transform job from s3 files and print output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3_client = sess.boto_session.client('s3')\n",
+    "s3_client.download_file(sess.default_bucket(), \"{}/iris.csv.out\".format(transform_output_folder), '/tmp/iris.csv.out')\n",
+    "with open('/tmp/iris.csv.out') as f:\n",
+    "    results = f.readlines()   \n",
+    "print(\"Transform results: \\n{}\".format(''.join(results)))"
    ]
   }
  ],
@@ -511,7 +599,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/advanced_functionality/scikit_bring_your_own/scikit_bring_your_own.ipynb
+++ b/advanced_functionality/scikit_bring_your_own/scikit_bring_your_own.ipynb
@@ -419,7 +419,7 @@
    "metadata": {},
    "source": [
     "## Hosting your model\n",
-    "One can use trained model to get real time predictions using HTTP endpoint. Following steps walk you through the process."
+    "You can use a trained model to get real time predictions using HTTP endpoint. Follow these steps to walk you through the process."
    ]
   },
   {
@@ -505,7 +505,7 @@
    "metadata": {},
    "source": [
     "## Run Batch Transform Job\n",
-    "One can use trained model to get inference on large data sets by using [Amazon SageMaker Batch Transform](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-batch.html). A Batch Transform Job takes your input data S3 location and publishes prediction result to specified S3 output folder. Similar to hosting, lets extract inferences for training data to demo Batch Transform mechanism."
+    "You can use a trained model to get inference on large data sets by using [Amazon SageMaker Batch Transform](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-batch.html). A batch transform job takes your input data S3 location and outputs the predictions to the specified S3 output folder. Similar to hosting, you can extract inferences for training data to test batch transform."
    ]
   },
   {
@@ -513,7 +513,7 @@
    "metadata": {},
    "source": [
     "### Create a Transform Job\n",
-    "We'll create an `Transformer` that defines how to use the container to get inference results on a data set. This includes the configuration we need to invoke SageMaker Batch transform:\n",
+    "We'll create an `Transformer` that defines how to use the container to get inference results on a data set. This includes the configuration we need to invoke SageMaker batch transform:\n",
     "\n",
     "* The __instance count__ which is the number of machines to use to extract inferences\n",
     "* The __instance type__ which is the type of machine to use to extract inferences\n",
@@ -538,7 +538,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use tranform() on the transfomer to get inference results against the data that we uploaded above. We provide below options when invoking transformer. \n",
+    "We use tranform() on the transfomer to get inference results against the data that we uploaded. You can use these options when invoking the transformer. \n",
+    "\n",
     "* The __data_location__ which is the location of input data\n",
     "* The __content_type__ which is the content type set when making HTTP request to container to get prediction\n",
     "* The __split_type__ which is the delimiter used for splitting input data "
@@ -558,7 +559,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more configuration options and details, please visit [CreateTransformJob API](https://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateTransformJob.html) page"
+    "For more information on the configuration options, see [CreateTransformJob API](https://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateTransformJob.html)"
    ]
   },
   {


### PR DESCRIPTION
1) Also adjusts request timeout in ngnix.conf to be more than 60 seconds as Batch transform do not have any limit on request timeout and some customers were running into this limit.  This should not effect SageMaker Hosting as it enforces 60 seconds timeout and fail the requests if it exceeds
the limit

2) Updated containers predictions code to ignore first column. It keeps flow simple, without needing to create another data source for batch

3) Updated algorithm name to include "sagemaker" as role created by sagemaker console only has access to resources with sagemaker in it.

4) Also fixes broken numpy version without which training fails

Followup on

Address cr comments from pr https://github.com/awslabs/amazon-sagemaker-examples/pull/544 Unfortunately I had to discard that request

a) Fixed broken links
b) Used cells instead of code comments where ever appropriate
c) Fixed formatting