### PR TITLE
Download CIFAR and MNIST dataset from S3

### DIFF
--- a/sagemaker-python-sdk/1P_kmeans_highlevel/kmeans_mnist.ipynb
+++ b/sagemaker-python-sdk/1P_kmeans_highlevel/kmeans_mnist.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "# Load the dataset\n",
     "region = boto3.Session().region_name\n",
-    "boto3.Session().resource('s3').Bucket('sagemaker-sample-data-{}'.format(region)).download_file('algorithms/kmeans/mnist/mnist.pkl.gz', 'mnist.pkl.gz')\n",
+    "boto3.Session().resource('s3', region_name=region).Bucket('sagemaker-sample-data-{}'.format(region)).download_file('algorithms/kmeans/mnist/mnist.pkl.gz', 'mnist.pkl.gz')\n",
     "with gzip.open('mnist.pkl.gz', 'rb') as f:\n",
     "    train_set, valid_set, test_set = pickle.load(f, encoding='latin1')"
    ]

--- a/sagemaker-python-sdk/1P_kmeans_highlevel/kmeans_mnist.ipynb
+++ b/sagemaker-python-sdk/1P_kmeans_highlevel/kmeans_mnist.ipynb
@@ -77,10 +77,11 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "import pickle, gzip, numpy, urllib.request, json\n",
+    "import pickle, gzip, numpy, boto3, json\n",
     "\n",
     "# Load the dataset\n",
-    "urllib.request.urlretrieve(\"http://deeplearning.net/data/mnist/mnist.pkl.gz\", \"mnist.pkl.gz\")\n",
+    "region = boto3.Session().region_name\n",
+    "boto3.Session().resource('s3').Bucket('sagemaker-sample-data-{}'.format(region)).download_file('algorithms/kmeans/mnist/mnist.pkl.gz', 'mnist.pkl.gz')\n",
     "with gzip.open('mnist.pkl.gz', 'rb') as f:\n",
     "    train_set, valid_set, test_set = pickle.load(f, encoding='latin1')"
    ]

--- a/sagemaker-python-sdk/1P_kmeans_lowlevel/kmeans_mnist_lowlevel.ipynb
+++ b/sagemaker-python-sdk/1P_kmeans_lowlevel/kmeans_mnist_lowlevel.ipynb
@@ -83,10 +83,11 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "import pickle, gzip, numpy, urllib.request, json\n",
+    "import pickle, gzip, numpy, boto3, json\n",
     "\n",
     "# Load the dataset\n",
-    "urllib.request.urlretrieve(\"http://deeplearning.net/data/mnist/mnist.pkl.gz\", \"mnist.pkl.gz\")\n",
+    "region = boto3.Session().region_name\n",
+    "boto3.Session().resource('s3').Bucket('sagemaker-sample-data-{}'.format(region)).download_file('algorithms/kmeans/mnist/mnist.pkl.gz', 'mnist.pkl.gz')\n",
     "with gzip.open('mnist.pkl.gz', 'rb') as f:\n",
     "    train_set, valid_set, test_set = pickle.load(f, encoding='latin1')"
    ]

--- a/sagemaker-python-sdk/1P_kmeans_lowlevel/kmeans_mnist_lowlevel.ipynb
+++ b/sagemaker-python-sdk/1P_kmeans_lowlevel/kmeans_mnist_lowlevel.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "# Load the dataset\n",
     "region = boto3.Session().region_name\n",
-    "boto3.Session().resource('s3').Bucket('sagemaker-sample-data-{}'.format(region)).download_file('algorithms/kmeans/mnist/mnist.pkl.gz', 'mnist.pkl.gz')\n",
+    "boto3.Session().resource('s3', region_name=region).Bucket('sagemaker-sample-data-{}'.format(region)).download_file('algorithms/kmeans/mnist/mnist.pkl.gz', 'mnist.pkl.gz')\n",
     "with gzip.open('mnist.pkl.gz', 'rb') as f:\n",
     "    train_set, valid_set, test_set = pickle.load(f, encoding='latin1')"
    ]

--- a/sagemaker-python-sdk/tensorflow_keras_cifar10/utils.py
+++ b/sagemaker-python-sdk/tensorflow_keras_cifar10/utils.py
@@ -1,15 +1,13 @@
 import os
 import sys
 import tarfile
+import boto3
 from six.moves import urllib
 from ipywidgets import FloatProgress
 from IPython.display import display
 
-DATA_URL = 'https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz'
-
 
 def cifar10_download(data_dir='/tmp/cifar10_data', print_progress=True):
-    """Download and extract the tarball from Alex's website."""
     if not os.path.exists(data_dir):
         os.makedirs(data_dir)
 
@@ -17,21 +15,11 @@ def cifar10_download(data_dir='/tmp/cifar10_data', print_progress=True):
         print('cifar dataset already downloaded')
         return
 
-    filename = DATA_URL.split('/')[-1]
+    filename = 'cifar-10-binary.tar.gz'
     filepath = os.path.join(data_dir, filename)
 
     if not os.path.exists(filepath):
-        f = FloatProgress(min=0, max=100)
-        display(f)
-        sys.stdout.write('\r>> Downloading %s ' % (filename))        
-
-        def _progress(count, block_size, total_size):
-            if print_progress:
-                f.value = 100.0 * count * block_size / total_size
-
-        filepath, _ = urllib.request.urlretrieve(DATA_URL, filepath, _progress)
-        print()
-        statinfo = os.stat(filepath)
-        print('Successfully downloaded', filename, statinfo.st_size, 'bytes.')
+        region = boto3.Session().region_name
+        boto3.Session().resource('s3').Bucket('sagemaker-sample-data-{}'.format(region)).download_file('tensorflow/cifar10/cifar-10-binary.tar.gz', '/tmp/cifar10_data/cifar-10-binary.tar.gz')
 
     tarfile.open(filepath, 'r:gz').extractall(data_dir)

--- a/sagemaker-python-sdk/tensorflow_keras_cifar10/utils.py
+++ b/sagemaker-python-sdk/tensorflow_keras_cifar10/utils.py
@@ -20,6 +20,6 @@ def cifar10_download(data_dir='/tmp/cifar10_data', print_progress=True):
 
     if not os.path.exists(filepath):
         region = boto3.Session().region_name
-        boto3.Session().resource('s3').Bucket('sagemaker-sample-data-{}'.format(region)).download_file('tensorflow/cifar10/cifar-10-binary.tar.gz', '/tmp/cifar10_data/cifar-10-binary.tar.gz')
+        boto3.Session().resource('s3', region_name=region).Bucket('sagemaker-sample-data-{}'.format(region)).download_file('tensorflow/cifar10/cifar-10-binary.tar.gz', '/tmp/cifar10_data/cifar-10-binary.tar.gz')
 
     tarfile.open(filepath, 'r:gz').extractall(data_dir)

--- a/sagemaker-python-sdk/tensorflow_resnet_cifar10_with_tensorboard/utils.py
+++ b/sagemaker-python-sdk/tensorflow_resnet_cifar10_with_tensorboard/utils.py
@@ -1,15 +1,13 @@
 import os
 import sys
 import tarfile
+import boto3
 from six.moves import urllib
 from ipywidgets import FloatProgress
 from IPython.display import display
 
-DATA_URL = 'https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz'
-
 
 def cifar10_download(data_dir='/tmp/cifar10_data', print_progress=True):
-    """Download and extract the tarball from Alex's website."""
     if not os.path.exists(data_dir):
         os.makedirs(data_dir)
 
@@ -17,21 +15,11 @@ def cifar10_download(data_dir='/tmp/cifar10_data', print_progress=True):
         print('cifar dataset already downloaded')
         return
 
-    filename = DATA_URL.split('/')[-1]
+    filename = 'cifar-10-binary.tar.gz'
     filepath = os.path.join(data_dir, filename)
 
     if not os.path.exists(filepath):
-        f = FloatProgress(min=0, max=100)
-        display(f)
-        sys.stdout.write('\r>> Downloading %s ' % (filename))        
-
-        def _progress(count, block_size, total_size):
-            if print_progress:
-                f.value = 100.0 * count * block_size / total_size
-
-        filepath, _ = urllib.request.urlretrieve(DATA_URL, filepath, _progress)
-        print()
-        statinfo = os.stat(filepath)
-        print('Successfully downloaded', filename, statinfo.st_size, 'bytes.')
+        region = boto3.Session().region_name
+        boto3.Session().resource('s3').Bucket('sagemaker-sample-data-{}'.format(region)).download_file('tensorflow/cifar10/cifar-10-binary.tar.gz', '/tmp/cifar10_data/cifar-10-binary.tar.gz')
 
     tarfile.open(filepath, 'r:gz').extractall(data_dir)

--- a/sagemaker-python-sdk/tensorflow_resnet_cifar10_with_tensorboard/utils.py
+++ b/sagemaker-python-sdk/tensorflow_resnet_cifar10_with_tensorboard/utils.py
@@ -20,6 +20,6 @@ def cifar10_download(data_dir='/tmp/cifar10_data', print_progress=True):
 
     if not os.path.exists(filepath):
         region = boto3.Session().region_name
-        boto3.Session().resource('s3').Bucket('sagemaker-sample-data-{}'.format(region)).download_file('tensorflow/cifar10/cifar-10-binary.tar.gz', '/tmp/cifar10_data/cifar-10-binary.tar.gz')
+        boto3.Session().resource('s3', region_name=region).Bucket('sagemaker-sample-data-{}'.format(region)).download_file('tensorflow/cifar10/cifar-10-binary.tar.gz', '/tmp/cifar10_data/cifar-10-binary.tar.gz')
 
     tarfile.open(filepath, 'r:gz').extractall(data_dir)


### PR DESCRIPTION
**Description of changes:**
This change updates notebooks to download MNIST and dataset from S3 to improve the stability of these notebooks since sometimes the connection to public downloading website would time out. 

**Testing**
Tested by running these 4 notebooks using notebook testing framework:
```
SUCCEEDED	/home/hnzha/amazon-sagemaker-examples/sagemaker-python-sdk/1P_kmeans_highlevel/kmeans_mnist.ipynb	PT10M36.343S
SUCCEEDED	/home/hnzha/amazon-sagemaker-examples/sagemaker-python-sdk/1P_kmeans_lowlevel/kmeans_mnist_lowlevel.ipynb	PT10M26.347S
SUCCEEDED	/home/hnzha/amazon-sagemaker-examples/sagemaker-python-sdk/tensorflow_keras_cifar10/tensorflow_keras_CIFAR10.ipynb	PT15M48.854S
SUCCEEDED	/home/hnzha/amazon-sagemaker-examples/sagemaker-python-sdk/tensorflow_resnet_cifar10_with_tensorboard/tensorflow_resnet_cifar10_with_tensorboard.ipynb	PT18M29.969S
```
