### PR TITLE
Fix Dockerfile in scikit_bring_your_own example

### DIFF
--- a/advanced_functionality/scikit_bring_your_own/container/Dockerfile
+++ b/advanced_functionality/scikit_bring_your_own/container/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
 # a significant amount of space. These optimizations save a fair amount of space in the
 # image, which reduces start up time.
 RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py && \
-    pip install numpy==1.16.2 scipy==1.2.1 scikit-learn=0.20.2 pandas flask gevent gunicorn && \
+    pip install numpy==1.16.2 scipy==1.2.1 scikit-learn==0.20.2 pandas flask gevent gunicorn && \
         (cd /usr/local/lib/python2.7/dist-packages/scipy/.libs; rm *; ln ../../numpy/.libs/* .) && \
         rm -rf /root/.cache
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
`build_and_push.sh` in `scikit_bring_you_own` failed with

```
Invalid requirement: 'scikit-learn=0.20.2'
= is not a valid operator. Did you mean == ?
```

This is a fix to the Dockefile to fix this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
