### PR TITLE
Update to Coach 0.11.1 for DeepRacer and ObjectTracker RL Sample Application

### DIFF
--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/rl_deepracer_coach_robomaker.ipynb
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/rl_deepracer_coach_robomaker.ipynb
@@ -423,7 +423,7 @@
     "                        source_dir='src',\n",
     "                        dependencies=[\"common/sagemaker_rl\"],\n",
     "                        toolkit=RLToolkit.COACH,\n",
-    "                        toolkit_version='0.11.0',\n",
+    "                        toolkit_version='0.11.1',\n",
     "                        framework=RLFramework.TENSORFLOW,\n",
     "                        role=role,\n",
     "                        train_instance_type=instance_type,\n",
@@ -506,7 +506,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation_application_bundle_location = \"https://s3-us-west-2.amazonaws.com/robomaker-applications-us-west-2-11d8d0439f6a/deep-racer/deep-racer-1.0.74.0.1.0.82.0/simulation_ws.tar.gz\"\n",
+    "simulation_application_bundle_location = \"https://s3-us-west-2.amazonaws.com/robomaker-applications-us-west-2-11d8d0439f6a/deep-racer/deep-racer-1.0.80.0.1.0.106.0/simulation_ws.tar.gz\"\n",
     "\n",
     "!wget {simulation_application_bundle_location}\n",
     "!aws s3 cp simulation_ws.tar.gz s3://{s3_bucket}/{bundle_s3_key}\n",

--- a/reinforcement_learning/rl_objecttracker_robomaker_coach_gazebo/rl_objecttracker_coach_robomaker.ipynb
+++ b/reinforcement_learning/rl_objecttracker_robomaker_coach_gazebo/rl_objecttracker_coach_robomaker.ipynb
@@ -375,7 +375,7 @@
     "                        source_dir='src',\n",
     "                        dependencies=[\"common/sagemaker_rl\"],\n",
     "                        toolkit=RLToolkit.COACH,\n",
-    "                        toolkit_version='0.11.0',\n",
+    "                        toolkit_version='0.11.1',\n",
     "                        framework=RLFramework.TENSORFLOW,\n",
     "                        role=role,\n",
     "                        train_instance_type=instance_type,\n",
@@ -447,7 +447,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulation_application_bundle_location = \"https://s3-us-west-2.amazonaws.com/robomaker-applications-us-west-2-11d8d0439f6a/object-tracker/object-tracker-1.0.74.0.1.0.105.0/simulation_ws.tar.gz\"\n",
+    "simulation_application_bundle_location = \"https://s3-us-west-2.amazonaws.com/robomaker-applications-us-west-2-11d8d0439f6a/object-tracker/object-tracker-1.0.80.0.1.0.130.0/simulation_ws.tar.gz\"\n",
     "\n",
     "!wget {simulation_application_bundle_location}\n",
     "!aws s3 cp simulation_ws.tar.gz s3://{s3_bucket}/{bundle_s3_key}\n",


### PR DESCRIPTION
*Description of changes:*
- Use Coach 0.11.1 in RLEstimator
- Use the latest Simulation Bundle that uses Coach 0.11.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
