### PR TITLE
correct import statement in preprocessing script

### DIFF
--- a/sagemaker-python-sdk/scikit_learn_iris/Scikit-learn Estimator Example With Batch Transform.ipynb
+++ b/sagemaker-python-sdk/scikit_learn_iris/Scikit-learn Estimator Example With Batch Transform.ipynb
@@ -119,7 +119,7 @@
     "import pandas as pd\n",
     "import os\n",
     "\n",
-    "from sklearn import svm\n",
+    "from sklearn import tree\n",
     "from sklearn.externals import joblib\n",
     "\n",
     "\n",


### PR DESCRIPTION
*Description of changes:* In this notebook, it displays the `scikit_learn_iris.py` file in markdown, however there is an error that may trip people up if they attempt to copy/paste it. Instead of `from sklearn import tree`, which is needed to use `tree.DecisionTreeClassifier()`, it says `from sklearn import svm`, which is not used.
This caused a bit of confusion for me at first until I verified that it was a typo by double-checking the actual `scikit_learn_iris.py` file in the same directory. I hope that this small change can help others as well!


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
