### PR TITLE
code change to fix an issue in security group with EC2-Classic type

### DIFF
--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/rl_deepracer_coach_robomaker.ipynb
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/rl_deepracer_coach_robomaker.ipynb
@@ -223,7 +223,7 @@
     "default_vpc = [vpc['VpcId'] for vpc in ec2.describe_vpcs()['Vpcs'] if vpc[\"IsDefault\"] == True][0]\n",
     "\n",
     "default_security_groups = [group[\"GroupId\"] for group in ec2.describe_security_groups()['SecurityGroups'] \\\n",
-    "                   if group[\"GroupName\"] == \"default\" and group[\"VpcId\"] == default_vpc]\n",
+    "                   if 'VpcId' in group and group[\"GroupName\"] == \"default\" and group[\"VpcId\"] == default_vpc]\n",
     "\n",
     "default_subnets = [subnet[\"SubnetId\"] for subnet in ec2.describe_subnets()[\"Subnets\"] \\\n",
     "                  if subnet[\"VpcId\"] == default_vpc and subnet['DefaultForAz']==True]\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The 6th code cell to configure VPC is not aware of security group with EC2-Class type, which is not bound to VPC. In this case, 'VpcId' attribute does not exist in a security group.

I suggest to add 'validation code' to check whether VpcId attribute is. The code change is 

```
ec2 = boto3.client('ec2')
default_vpc = [vpc['VpcId'] for vpc in ec2.describe_vpcs()['Vpcs'] if vpc["IsDefault"] == True][0]

default_security_groups = [group["GroupId"] for group in ec2.describe_security_groups()['SecurityGroups'] \
                   if group["GroupName"] == "default" and group["VpcId"] == default_vpc]
```

to

```
ec2 = boto3.client('ec2')
default_vpc = [vpc['VpcId'] for vpc in ec2.describe_vpcs()['Vpcs'] if vpc["IsDefault"] == True][0]

default_security_groups = [group["GroupId"] for group in ec2.describe_security_groups()['SecurityGroups'] \
                   if 'VpcId' in group and group["GroupName"] == "default" and group["VpcId"] == default_vpc]
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
