### PR TITLE
Update instance type for kmeans training from c4.8xlarge to c4.xlarge

### DIFF
--- a/sagemaker-python-sdk/1P_kmeans_highlevel/kmeans_mnist.ipynb
+++ b/sagemaker-python-sdk/1P_kmeans_highlevel/kmeans_mnist.ipynb
@@ -125,7 +125,7 @@
     "\n",
     "Once we have the data preprocessed and available in the correct format for training, the next step is to actually train the model using the data. Since this data is relatively small, it isn't meant to show off the performance of the k-means training algorithm.  But Amazon SageMaker's k-means has been tested on, and scales well with, multi-terabyte datasets.\n",
     "\n",
-    "After setting training parameters, we kick off training, and poll for status until training is completed, which in this example, takes between 7 and 11 minutes."
+    "After setting training parameters, we kick off training, and poll for status until training is completed, which in this example, takes around 4 minutes."
    ]
   },
   {
@@ -144,7 +144,7 @@
     "\n",
     "kmeans = KMeans(role=role,\n",
     "                train_instance_count=2,\n",
-    "                train_instance_type='ml.c4.8xlarge',\n",
+    "                train_instance_type='ml.c4.xlarge',\n",
     "                output_path=output_location,\n",
     "                k=10,\n",
     "                data_location=data_location)"


### PR DESCRIPTION
**Description**
* Update instance type for kmeans training on mnist dataset from c4.8xlarge to c4.xlarge
since c4.8xlarge capacity is lower than c4.xlarge and mnist doesn't require this much compute.
* Update timing for training in comment, the data for timing is observed from over 100 training
jobs for kmeans with mnist dataset.

**Testing Done**
* Run the notebook with updated instance type

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
