### PR TITLE
Move magic matplotlib inline at top of the notebooks

### DIFF
--- a/sagemaker-python-sdk/1P_kmeans_highlevel/kmeans_mnist.ipynb
+++ b/sagemaker-python-sdk/1P_kmeans_highlevel/kmeans_mnist.ipynb
@@ -47,6 +47,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "isConfigCell": true
    },
@@ -101,7 +110,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "plt.rcParams[\"figure.figsize\"] = (2,10)\n",
     "\n",

--- a/sagemaker-python-sdk/1P_kmeans_lowlevel/kmeans_mnist_lowlevel.ipynb
+++ b/sagemaker-python-sdk/1P_kmeans_lowlevel/kmeans_mnist_lowlevel.ipynb
@@ -50,6 +50,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": true,
     "isConfigCell": true
@@ -109,7 +118,6 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "plt.rcParams[\"figure.figsize\"] = (2,10)\n",
     "\n",


### PR DESCRIPTION
**Description**
* Move magic matplotlib inline at top of the notebook to
avoid "RuntimeError: dictionary changed size during iteration"
error which occurs when some other thread udpate the globals
while magic matplotlib inline is iterating over globals.

**Testing Done**
* Run both notebooks with changes

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
