### PR TITLE
Strip out special characters from dataset row before converting token to int

### DIFF
--- a/sagemaker-python-sdk/mxnet_gluon_sentiment/sentiment.py
+++ b/sagemaker-python-sdk/mxnet_gluon_sentiment/sentiment.py
@@ -252,7 +252,7 @@ def get_dataset(filename):
     with open(filename) as f:
         for line in f:
             tokens = line.split()
-            label = int(tokens[0])
+            label = int(tokens[0].replace(':', '').replace(',', '').strip())
             words = tokens[1:]
             max_length = max(max_length, len(words))
             labels.append(label)

--- a/sagemaker-python-sdk/mxnet_gluon_sentiment/sentiment.py
+++ b/sagemaker-python-sdk/mxnet_gluon_sentiment/sentiment.py
@@ -252,6 +252,7 @@ def get_dataset(filename):
     with open(filename) as f:
         for line in f:
             tokens = line.split()
+            # Clean the data by stripping out special characters before converting label to int
             label = int(tokens[0].replace(':', '').replace(',', '').strip())
             words = tokens[1:]
             max_length = max(max_length, len(words))


### PR DESCRIPTION
### Motivation
* Following error occurred during training job
```
Invoking script with the following command:
/usr/bin/python -m sentiment --batch-size 8 --embedding-size 50 --epochs 2 --learning-rate 0.01 --log-interval 1000

Traceback (most recent call last):
File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
"__main__", fname, loader, pkg_name)
File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
exec code in run_globals
File "/opt/ml/code/sentiment.py", line 338, in <module>
args.batch_size, args.epochs, args.learning_rate, args.log_interval, args.embedding_size)
File "/opt/ml/code/sentiment.py", line 37, in train
train_sentences, train_labels, _ = get_dataset(training_dir + '/train')
File "/opt/ml/code/sentiment.py", line 255, in get_dataset
label = int(tokens[0])
ValueError: invalid literal for int() with base 10: '500:'
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
