### PR TITLE
Specify the framework_version in tensorflow_iris_byom

### DIFF
--- a/advanced_functionality/tensorflow_iris_byom/tensorflow_BYOM_iris.ipynb
+++ b/advanced_functionality/tensorflow_iris_byom/tensorflow_BYOM_iris.ipynb
@@ -234,6 +234,7 @@
     "from sagemaker.tensorflow.model import TensorFlowModel\n",
     "sagemaker_model = TensorFlowModel(model_data = 's3://' + sagemaker_session.default_bucket() + '/model/model.tar.gz',\n",
     "                                  role = role,\n",
+    "                                  framework_version = '1.12',\n",
     "                                  entry_point = 'iris_dnn_classifier.py')"
    ]
   },


### PR DESCRIPTION
This specifies the TensorFlow framework version in the bring-your-own-model example, so that users with later versions of TensorFlow can properly bring the built model into SageMaker.

*Issue #, if available:*

*Description of changes:*

Updates the BYOM example to explicitly specify a framework version for better compatibility with recent TF versions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
