### PR TITLE
Fix Chainer MNIST local mode notebook

### DIFF
--- a/sagemaker-python-sdk/chainer_mnist/chainer_mnist_local_mode.ipynb
+++ b/sagemaker-python-sdk/chainer_mnist/chainer_mnist_local_mode.ipynb
@@ -307,9 +307,6 @@
    },
    "outputs": [],
    "source": [
-    "import glob\n",
-    "import shutil\n",
-    "\n",
     "try:\n",
     "    os.makedirs('output/single_machine_mnist')\n",
     "except OSError:\n",
@@ -320,8 +317,8 @@
     "desc = chainer_estimator.sagemaker_session.sagemaker_client. \\\n",
     "           describe_training_job(TrainingJobName=chainer_training_job)\n",
     "output_data = desc['ModelArtifacts']['S3ModelArtifacts'].replace('model', 'output')\n",
-    "for file in glob.glob(output_data + '/**/*.png', recursive=True):\n",
-    "    shutil.copy(file, 'output/single_machine_mnist')"
+    "!aws --region {sagemaker_session.boto_session.region_name} s3 cp {output_data} output/single_machine_mnist/output.tar\n",
+    "!tar -xzvf output/single_machine_mnist/output.tar -C output/single_machine_mnist"
    ]
   },
   {


### PR DESCRIPTION
Local mode now uploads output to S3 which breaks the output analysis part of the
notebook. This change downloads the output files from S3 and extract it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
