### PR TITLE
Remove usage of tensorflow.contrib.learn since it is deprecated

### DIFF
--- a/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_distributed_mnist.ipynb
+++ b/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_distributed_mnist.ipynb
@@ -51,10 +51,10 @@
    "outputs": [],
    "source": [
     "import utils\n",
-    "from tensorflow.contrib.learn.python.learn.datasets import mnist\n",
+    "from tensorflow.examples.tutorials.mnist import input_data\n",
     "import tensorflow as tf\n",
     "\n",
-    "data_sets = mnist.read_data_sets('data', dtype=tf.uint8, reshape=False, validation_size=5000)\n",
+    "data_sets = input_data.read_data_sets('data', dtype=tf.uint8, reshape=False, validation_size=5000)\n",
     "\n",
     "utils.convert_to(data_sets.train, 'train', 'data')\n",
     "utils.convert_to(data_sets.validation, 'validation', 'data')\n",

--- a/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_local_mode_mnist.ipynb
+++ b/sagemaker-python-sdk/tensorflow_distributed_mnist/tensorflow_local_mode_mnist.ipynb
@@ -67,10 +67,10 @@
    "outputs": [],
    "source": [
     "import utils\n",
-    "from tensorflow.contrib.learn.python.learn.datasets import mnist\n",
+    "from tensorflow.examples.tutorials.mnist import input_data\n",
     "import tensorflow as tf\n",
     "\n",
-    "data_sets = mnist.read_data_sets('data', dtype=tf.uint8, reshape=False, validation_size=5000)\n",
+    "data_sets = input_data.read_data_sets('data', dtype=tf.uint8, reshape=False, validation_size=5000)\n",
     "\n",
     "utils.convert_to(data_sets.train, 'train', 'data')\n",
     "utils.convert_to(data_sets.validation, 'validation', 'data')\n",


### PR DESCRIPTION
Testing Done : Run the notebook after change

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
