### PR TITLE
Don't check for certificate hpo_xgboost_random_log.ipynb

### DIFF
--- a/hyperparameter_tuning/xgboost_random_log/hpo_xgboost_random_log.ipynb
+++ b/hyperparameter_tuning/xgboost_random_log/hpo_xgboost_random_log.ipynb
@@ -79,7 +79,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget -N https://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank-additional.zip\n",
+    "!wget -N --no-check-certificate https://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank-additional.zip\n",
     "!unzip -o bank-additional.zip"
    ]
   },


### PR DESCRIPTION
UCI is having certificate problems, as we are announcing the feature now we work around it for now with --no-check-certificate

It does not constitute a big risk as we are treated the file purely as a dataset, it never gets executed.