### PR TITLE
Remove --no-check-certificate  again

### DIFF
--- a/hyperparameter_tuning/xgboost_random_log/hpo_xgboost_random_log.ipynb
+++ b/hyperparameter_tuning/xgboost_random_log/hpo_xgboost_random_log.ipynb
@@ -79,7 +79,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget -N --no-check-certificate https://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank-additional.zip\n",
+    "!wget -N https://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank-additional.zip\n",
     "!unzip -o bank-additional.zip"
    ]
   },


### PR DESCRIPTION
Now that UCI has solved their previous certificate issue we can remove --no-check-certificate again