### PR TITLE
Fix number of evaluation steps for reinforcement learning notebooks II

### DIFF
--- a/reinforcement_learning/rl_mountain_car_coach_gymEnv/rl_mountain_car_coach_gymEnv.ipynb
+++ b/reinforcement_learning/rl_mountain_car_coach_gymEnv/rl_mountain_car_coach_gymEnv.ipynb
@@ -495,7 +495,7 @@
     "                             train_instance_type=instance_type,\n",
     "                             hyperparameters = {\n",
     "                                 \"RLCOACH_PRESET\": \"preset-mountain-car-continuous-clipped-ppo\",\n",
-    "                                 \"evaluate_steps\": 2000\n",
+    "                                 \"evaluate_steps\": 10000*2 # evaluate on 2 episodes\n",
     "                             }\n",
     "                            )\n",
     "\n",

--- a/reinforcement_learning/rl_portfolio_management_coach_customEnv/rl_portfolio_management_coach_customEnv.ipynb
+++ b/reinforcement_learning/rl_portfolio_management_coach_customEnv/rl_portfolio_management_coach_customEnv.ipynb
@@ -559,7 +559,9 @@
     "                      entry_point=\"evaluate-coach.py\",\n",
     "                      train_instance_count=1,\n",
     "                      train_instance_type=instance_type,\n",
-    "                      hyperparameters = {}\n",
+    "                      hyperparameters = {\n",
+    "                          \"evaluate_steps\": 731*2 # evaluate on 2 episodes\n",
+    "                      }\n",
     "                    )\n",
     "estimator_eval.fit({'checkpoint': checkpoint_path})"
    ]

--- a/reinforcement_learning/rl_predictive_autoscaling_coach_customEnv/rl_predictive_autoscaling_coach_customEnv.ipynb
+++ b/reinforcement_learning/rl_predictive_autoscaling_coach_customEnv/rl_predictive_autoscaling_coach_customEnv.ipynb
@@ -525,7 +525,7 @@
     "                      train_instance_type=instance_type,\n",
     "                      hyperparameters = {\n",
     "                                 \"RLCOACH_PRESET\": \"preset-autoscale-ppo\",\n",
-    "                                 \"evaluate_steps\": 2000\n",
+    "                                 \"evaluate_steps\": 10001*2 # evaluate on 2 episodes\n",
     "                             }\n",
     "                    )\n",
     "estimator_eval.fit({'checkpoint': checkpoint_path})"


### PR DESCRIPTION
*Issue #, if available:*
Fixed and tested the reinforcement learning notebooks: moutain car, auto-scaling and portfolio management. Changed the value according to episode length in each example.

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
