### PR TITLE
fix sagemaker-containers readme link

### DIFF
--- a/sagemaker-python-sdk/tensorflow_script_mode_horovod/tensorflow_script_mode_horovod.ipynb
+++ b/sagemaker-python-sdk/tensorflow_script_mode_horovod/tensorflow_script_mode_horovod.ipynb
@@ -119,7 +119,7 @@
     "parser.add_argument('--model_dir', type=str)\n",
     "```\n",
     "\n",
-    "More details can be found [here](https://github.com/aws/sagemaker-containers/blob/master/README.md)."
+    "More details can be found [here](https://github.com/aws/sagemaker-containers/blob/master/README.rst)."
    ]
   },
   {
@@ -141,7 +141,7 @@
     "y_test = np.load(os.path.join(os.environ['SM_CHANNEL_TEST'], 'test.npz'))['labels']\n",
     "```\n",
     "\n",
-    "For a list of all environment variables set by SageMaker that are accessible inside a training script, see [SageMaker Containers](https://github.com/aws/sagemaker-containers/blob/master/README.md)."
+    "For a list of all environment variables set by SageMaker that are accessible inside a training script, see [SageMaker Containers](https://github.com/aws/sagemaker-containers/blob/master/README.rst)."
    ]
   },
   {

--- a/sagemaker-python-sdk/tensorflow_script_mode_quickstart/tensorflow_script_mode_quickstart.ipynb
+++ b/sagemaker-python-sdk/tensorflow_script_mode_quickstart/tensorflow_script_mode_quickstart.ipynb
@@ -255,7 +255,7 @@
     "  parser.add_argument('--data_dir', type=str, default=os.environ['SM_CHANNEL_TRAINING'])\n",
     "```\n",
     "\n",
-    "Script mode displays the list of available environment variables in the training logs. You can find the [entire list here](https://github.com/aws/sagemaker-containers/blob/master/README.md#environment-variables-full-specification)."
+    "Script mode displays the list of available environment variables in the training logs. You can find the [entire list here](https://github.com/aws/sagemaker-containers/blob/master/README.rst#list-of-provided-environment-variables-by-sagemaker-containers)."
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-sagemaker-examples/issues/738

*Description of changes:*
The SageMaker containers readme was changed from README.md to README.rst: https://github.com/aws/sagemaker-containers/pull/183

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
