### PR TITLE
Upgrade PyTorch version to 1.1.0

### DIFF
--- a/sagemaker-python-sdk/pytorch_cnn_cifar10/pytorch_local_mode_cifar10.ipynb
+++ b/sagemaker-python-sdk/pytorch_cnn_cifar10/pytorch_local_mode_cifar10.ipynb
@@ -196,7 +196,7 @@
     "\n",
     "cifar10_estimator = PyTorch(entry_point='source/cifar10.py',\n",
     "                            role=role,\n",
-    "                            framework_version='1.0.0',\n",
+    "                            framework_version='1.1.0',\n",
     "                            train_instance_count=1,\n",
     "                            train_instance_type=instance_type)\n",
     "\n",

--- a/sagemaker-python-sdk/pytorch_lstm_word_language_model/pytorch_rnn.ipynb
+++ b/sagemaker-python-sdk/pytorch_lstm_word_language_model/pytorch_rnn.ipynb
@@ -184,7 +184,7 @@
     "\n",
     "estimator = PyTorch(entry_point='train.py',\n",
     "                    role=role,\n",
-    "                    framework_version='1.0.0',\n",
+    "                    framework_version='1.1.0',\n",
     "                    train_instance_count=1,\n",
     "                    train_instance_type='ml.p2.xlarge',\n",
     "                    source_dir='source',\n",

--- a/sagemaker-python-sdk/pytorch_mnist/mnist.py
+++ b/sagemaker-python-sdk/pytorch_mnist/mnist.py
@@ -43,7 +43,7 @@ def _get_train_data_loader(batch_size, training_dir, is_distributed, **kwargs):
     dataset = datasets.MNIST(training_dir, train=True, transform=transforms.Compose([
         transforms.ToTensor(),
         transforms.Normalize((0.1307,), (0.3081,))
-    ]))
+    ]), download=True)
     train_sampler = torch.utils.data.distributed.DistributedSampler(dataset) if is_distributed else None
     return torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=train_sampler is None,
                                        sampler=train_sampler, **kwargs)
@@ -55,7 +55,7 @@ def _get_test_data_loader(test_batch_size, training_dir, **kwargs):
         datasets.MNIST(training_dir, train=False, transform=transforms.Compose([
             transforms.ToTensor(),
             transforms.Normalize((0.1307,), (0.3081,))
-        ])),
+        ]), download=True),
         batch_size=test_batch_size, shuffle=True, **kwargs)
 
 

--- a/sagemaker-python-sdk/pytorch_mnist/pytorch_mnist.ipynb
+++ b/sagemaker-python-sdk/pytorch_mnist/pytorch_mnist.ipynb
@@ -156,7 +156,7 @@
     "\n",
     "estimator = PyTorch(entry_point='mnist.py',\n",
     "                    role=role,\n",
-    "                    framework_version='1.0.0',\n",
+    "                    framework_version='1.1.0',\n",
     "                    train_instance_count=2,\n",
     "                    train_instance_type='ml.c4.xlarge',\n",
     "                    hyperparameters={\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump PyTorch example framework version. Do not merge because 1.1.0 images are not deployed yet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
