### PR TITLE
Remove sentence that does not apply

### DIFF
--- a/introduction_to_amazon_algorithms/imageclassification_caltech/Image-classification-incremental-training-highlevel.ipynb
+++ b/introduction_to_amazon_algorithms/imageclassification_caltech/Image-classification-incremental-training-highlevel.ipynb
@@ -316,7 +316,7 @@
     "\n",
     "***\n",
     "\n",
-    "We can now use the trained model to perform inference. For this example, that means predicting the topic mixture representing a given document. You can deploy the created model by using the deploy method in the estimator"
+    "We can now use the trained model to perform inference. You can deploy the created model by using the deploy method in the estimator"
    ]
   },
   {


### PR DESCRIPTION
This pull request is correct a sentence in the example notebook below:

[End-to-End Incremental Training Image Classification Example](https://github.com/awslabs/amazon-sagemaker-examples/blob/master/introduction_to_amazon_algorithms/imageclassification_caltech/Image-classification-incremental-training-highlevel.ipynb)

The sentence that need to be removed does not apply to image classification.
This is the sentence that need to be removed/edited.
"For this example, that means predicting the topic mixture representing a given document."


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.