### PR TITLE
Move removing first column to notebook instead of predict.py

### DIFF
--- a/advanced_functionality/scikit_bring_your_own/container/decision_trees/predictor.py
+++ b/advanced_functionality/scikit_bring_your_own/container/decision_trees/predictor.py
@@ -72,9 +72,6 @@ def transformation():
 
     print('Invoked with {} records'.format(data.shape[0]))
 
-    # Drop first column, since sample notebook uses training data to show case predictions
-    data.drop(data.columns[[0]],axis=1,inplace=True)
-
     # Do the prediction
     predictions = ScoringService.predict(data)
 

--- a/advanced_functionality/scikit_bring_your_own/scikit_bring_your_own.ipynb
+++ b/advanced_functionality/scikit_bring_your_own/scikit_bring_your_own.ipynb
@@ -146,7 +146,7 @@
     "\n",
     "#### Running your container during hosting\n",
     "\n",
-    "Hosting has a very different model than training because hosting is reponding to inference requests that come in via HTTP. In this example, we use our recommended Python serving stack to provide robust and scalable serving of inference requests:\n",
+    "Hosting has a very different model than training because hosting is responding to inference requests that come in via HTTP. In this example, we use our recommended Python serving stack to provide robust and scalable serving of inference requests:\n",
     "\n",
     "![Request serving stack](stack.png)\n",
     "\n",
@@ -466,7 +466,8 @@
     "b = [40+i for i in range(10)]\n",
     "indices = [i+j for i,j in itertools.product(a,b)]\n",
     "\n",
-    "test_data=shape.iloc[indices[:-1]]"
+    "test_data = shape.iloc[indices[:-1]]\n",
+    "test_data = test_data.drop(test_data.columns[[0]], axis=1)"
    ]
   },
   {


### PR DESCRIPTION
*Description of changes:*
Moved first-column-remove logic to notebook instead of prediction.

Running local prediction gives an error and it was clear removing first column from [payload](https://github.com/awslabs/amazon-sagemaker-examples/blob/master/advanced_functionality/scikit_bring_your_own/container/local_test/payload.csv) data will change the data shape.

`ValueError: Number of features of the model must match the input. Model n_features is 4 and input n_features is 3`

On the other hand test data used in deployment example is the same like training data, hence first column must be removed before prediction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
