### PR TITLE
use_pretrained_model=1 for better accuracy

### DIFF
--- a/sagemaker_neo_compilation_jobs/imageclassification_caltech/Image-classification-fulltraining-highlevel-neo.ipynb
+++ b/sagemaker_neo_compilation_jobs/imageclassification_caltech/Image-classification-fulltraining-highlevel-neo.ipynb
@@ -191,6 +191,7 @@
     "                             epochs=5,\n",
     "                             learning_rate=0.01,\n",
     "                             top_k=2,\n",
+    "                             use_pretrained_model=1,\n",
     "                             precision_dtype='float32')"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*
Out-of-the-box Image-classification-fulltraining-highlevel-neo.ipynb does not offer great accuracy because it does not use pre-trained model

*Description of changes:*
set "use_pretrained_model=1"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
