### PR TITLE
Update ray launcher and evaluation script to be compatible with ray 0…

### DIFF
--- a/reinforcement_learning/rl_roboschool_ray/Dockerfile
+++ b/reinforcement_learning/rl_roboschool_ray/Dockerfile
@@ -1,6 +1,6 @@
 ARG CPU_OR_GPU
 ARG AWS_REGION
-FROM 520713654638.dkr.ecr.${AWS_REGION}.amazonaws.com/sagemaker-rl-tensorflow:ray0.5.3-${CPU_OR_GPU}-py3
+FROM 520713654638.dkr.ecr.${AWS_REGION}.amazonaws.com/sagemaker-rl-tensorflow:ray0.6.5-${CPU_OR_GPU}-py3
 
 WORKDIR /opt/ml
 


### PR DESCRIPTION
Update ray launcher and evaluation script to be compatible with ray 0…

*Issue #, if available:*
Current ray rllib notebook only works with ray version 0.5.3.

*Description of changes:*
Making change on ray_launcher.py and evaluate-ray.py to be compatible to both ray version of 0.5.3 and 0.6.5.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
