### PR TITLE
Fixed broken links

### DIFF
--- a/sagemaker-python-sdk/README.md
+++ b/sagemaker-python-sdk/README.md
@@ -19,8 +19,8 @@ These examples focus on the Amazon SageMaker Python SDK which allows you to writ
 - [Introduction to Estimators in TensorFlow](tensorflow_iris_dnn_classifier_using_estimators)
 - [TensorFlow and TensorBoard](tensorflow_resnet_cifar10_with_tensorboard)
 - [Distributed TensorFlow](tensorflow_distributed_mnist)
-- [Managed Spot Training on MXNet](spot_training_mxnet)
-- [Managed Spot Training on TensorFlow](spot_training_tensorflow_estimator)
+- [Managed Spot Training on MXNet](managed_spot_training_mxnet)
+- [Managed Spot Training on TensorFlow](managed_spot_training_tensorflow_estimator)
 
 #### Using pre-trained ONNX models with Amazon SageMaker
 


### PR DESCRIPTION
*Issue #, if available:*
The links to the Sagemaker spot training on MXNet and Tensor flow are broken

*Description of changes:*
Fixed the broken links
Solves #892 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
