### PR TITLE
Add sample notebooks for multi-model endpoints functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ These examples that showcase unique functionality available in Amazon SageMaker.
 - [Inference Pipeline with SparkML and XGBoost](advanced_functionality/inference_pipeline_sparkml_xgboost_abalone) shows how to deploy an Inference Pipeline with SparkML for data pre-processing and XGBoost for training on the Abalone dataset. The pre-processing code is written once and used between training and inference.
 - [Inference Pipeline with SparkML and BlazingText](advanced_functionality/inference_pipeline_sparkml_blazingtext_dbpedia) shows how to deploy an Inference Pipeline with SparkML for data pre-processing and BlazingText for training on the DBPedia dataset. The pre-processing code is written once and used between training and inference.
 - [Experiment Management Capabilities with Search](advanced_functionality/search) shows how to organize Training Jobs into projects, and track relationships between Models, Endpoints, and Training Jobs.
+- [Host Multiple Models with Your Own Algorithm](advanced_functionality/multi_model_bring_your_own) shows how to deploy multiple models to a realtime hosted endpoint with your own custom algorithm.
+- [Host Multiple Models with XGBoost](advanced_functionality/multi_model_xgboost_home_value) shows how to deploy multiple models to a realtime hosted endpoint using a multi-model enabled XGBoost container.
+- [Host Multiple Models with SKLearn](advanced_functionality/multi_model_sklearn_home_value) shows how to deploy multiple models to a realtime hosted endpoint using a multi-model enabled SKLearn container.
 
 ### Amazon SageMaker Neo Compilation Jobs
 

--- a/advanced_functionality/multi_model_bring_your_own/container/Dockerfile
+++ b/advanced_functionality/multi_model_bring_your_own/container/Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu:16.04
+
+# Set a docker label to advertise multi-model support on the container
+LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
+# Set a docker label to enable container to use SAGEMAKER_BIND_TO_PORT environment variable if present
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
+
+# Install necessary dependencies for MMS and SageMaker Inference Toolkit
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    openjdk-8-jdk-headless \
+    python3-dev \
+    curl \
+    vim \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -O https://bootstrap.pypa.io/get-pip.py \
+    && python3 get-pip.py
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+RUN update-alternatives --install /usr/local/bin/pip pip /usr/local/bin/pip3 1
+
+# Install MXNet, MMS, and SageMaker Inference Toolkit to set up MMS
+RUN pip3 --no-cache-dir install mxnet \
+                                multi-model-server \
+                                sagemaker-inference \
+                                retrying
+
+# Copy entrypoint script to the image
+COPY dockerd-entrypoint.py /usr/local/bin/dockerd-entrypoint.py
+RUN chmod +x /usr/local/bin/dockerd-entrypoint.py
+
+RUN mkdir -p /home/model-server/
+
+# Copy the default custom service file to handle incoming data and inference requests
+COPY model_handler.py /home/model-server/model_handler.py
+
+# Define an entrypoint script for the docker image
+ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]
+
+# Define command to be passed to the entrypoint
+CMD ["serve"]

--- a/advanced_functionality/multi_model_bring_your_own/container/dockerd-entrypoint.py
+++ b/advanced_functionality/multi_model_bring_your_own/container/dockerd-entrypoint.py
@@ -1,0 +1,29 @@
+import subprocess
+import sys
+import shlex
+import os
+from retrying import retry
+from subprocess import CalledProcessError
+from sagemaker_inference import model_server
+
+def _retry_if_error(exception):
+    return isinstance(exception, CalledProcessError or OSError)
+
+@retry(stop_max_delay=1000 * 50,
+       retry_on_exception=_retry_if_error)
+def _start_mms():
+    # by default the number of workers per model is 1, but we can configure it through the
+    # environment variable below if desired.
+    # os.environ['SAGEMAKER_MODEL_SERVER_WORKERS'] = '2'
+    model_server.start_model_server(handler_service='/home/model-server/model_handler.py:handle')
+
+def main():
+    if sys.argv[1] == 'serve':
+        _start_mms()
+    else:
+        subprocess.check_call(shlex.split(' '.join(sys.argv[1:])))
+
+    # prevent docker exit
+    subprocess.call(['tail', '-f', '/dev/null'])
+    
+main()

--- a/advanced_functionality/multi_model_bring_your_own/container/model_handler.py
+++ b/advanced_functionality/multi_model_bring_your_own/container/model_handler.py
@@ -1,0 +1,167 @@
+"""
+ModelHandler defines an example model handler for load and inference requests for MXNet CPU models
+"""
+from collections import namedtuple
+import glob
+import json
+import logging
+import os
+import re
+
+import mxnet as mx
+import numpy as np
+
+class ModelHandler(object):
+    """
+    A sample Model handler implementation.
+    """
+
+    def __init__(self):
+        self.initialized = False
+        self.mx_model = None
+        self.shapes = None
+
+    def get_model_files_prefix(self, model_dir):
+        """
+        Get the model prefix name for the model artifacts (symbol and parameter file).
+        This assume model artifact directory contains a symbol file, parameter file, 
+        model shapes file and a synset file defining the labels
+
+        :param model_dir: Path to the directory with model artifacts
+        :return: prefix string for model artifact files
+        """
+        sym_file_suffix = "-symbol.json"
+        checkpoint_prefix_regex = "{}/*{}".format(model_dir, sym_file_suffix) # Ex output: /opt/ml/models/resnet-18/model/*-symbol.json
+        checkpoint_prefix_filename = glob.glob(checkpoint_prefix_regex)[0] # Ex output: /opt/ml/models/resnet-18/model/resnet18-symbol.json
+        checkpoint_prefix = os.path.basename(checkpoint_prefix_filename).split(sym_file_suffix)[0] # Ex output: resnet18
+        logging.info("Prefix for the model artifacts: {}".format(checkpoint_prefix))
+        return checkpoint_prefix
+
+    def get_input_data_shapes(self, model_dir, checkpoint_prefix):
+        """
+        Get the model input data shapes and return the list
+
+        :param model_dir: Path to the directory with model artifacts
+        :param checkpoint_prefix: Model files prefix name
+        :return: prefix string for model artifact files
+        """
+        shapes_file_path = os.path.join(model_dir, "{}-{}".format(checkpoint_prefix, "shapes.json"))
+        if not os.path.isfile(shapes_file_path):
+            raise RuntimeError("Missing {} file.".format(shapes_file_path))
+
+        with open(shapes_file_path) as f:
+            self.shapes = json.load(f)
+
+        data_shapes = []
+
+        for input_data in self.shapes:
+            data_name = input_data["name"]
+            data_shape = input_data["shape"]
+            data_shapes.append((data_name, tuple(data_shape)))
+
+        return data_shapes
+
+    def initialize(self, context):
+        """
+        Initialize model. This will be called during model loading time
+        :param context: Initial context contains model server system properties.
+        :return:
+        """
+        self.initialized = True
+        properties = context.system_properties
+        # Contains the url parameter passed to the load request
+        model_dir = properties.get("model_dir") 
+        gpu_id = properties.get("gpu_id")
+
+        checkpoint_prefix = self.get_model_files_prefix(model_dir)
+
+        # Read the model input data shapes
+        data_shapes = self.get_input_data_shapes(model_dir, checkpoint_prefix)
+         
+        # Load MXNet model
+        try:
+            ctx = mx.cpu() # Set the context on CPU
+            sym, arg_params, aux_params = mx.model.load_checkpoint(checkpoint_prefix, 0)  # epoch set to 0
+            self.mx_model = mx.mod.Module(symbol=sym, context=ctx, label_names=None)
+            self.mx_model.bind(for_training=False, data_shapes=data_shapes, 
+                   label_shapes=self.mx_model._label_shapes)
+            self.mx_model.set_params(arg_params, aux_params, allow_missing=True)
+            with open("synset.txt", 'r') as f:
+                self.labels = [l.rstrip() for l in f]
+        except (mx.base.MXNetError, RuntimeError) as memerr:
+            if re.search('Failed to allocate (.*) Memory', str(memerr), re.IGNORECASE):
+                logging.error("Memory allocation exception: {}".format(memerr))
+                raise MemoryError
+            raise           
+
+    def preprocess(self, request):
+        """
+        Transform raw input into model input data.
+        :param request: list of raw requests
+        :return: list of preprocessed model input data
+        """
+        # Take the input data and pre-process it make it inference ready
+
+        img_list = []
+        for idx, data in enumerate(request):
+            # Read the bytearray of the image from the input
+            img_arr = data.get('body')  
+
+            # Input image is in bytearray, convert it to MXNet NDArray
+            img = mx.img.imdecode(img_arr) 
+            if img is None:
+                return None
+
+            # convert into format (batch, RGB, width, height)
+            img = mx.image.imresize(img, 224, 224) # resize
+            img = img.transpose((2, 0, 1)) # Channel first
+            img = img.expand_dims(axis=0) # batchify
+            img_list.append(img)
+
+        return img_list
+
+    def inference(self, model_input):
+        """
+        Internal inference methods
+        :param model_input: transformed model input data list
+        :return: list of inference output in NDArray
+        """
+        # Do some inference call to engine here and return output
+        Batch = namedtuple('Batch', ['data'])
+        self.mx_model.forward(Batch(model_input))
+        prob = self.mx_model.get_outputs()[0].asnumpy()
+        return prob
+
+    def postprocess(self, inference_output):
+        """
+        Return predict result in as list.
+        :param inference_output: list of inference output
+        :return: list of predict results
+        """
+        # Take output from network and post-process to desired format
+        prob = np.squeeze(inference_output)
+        a = np.argsort(prob)[::-1]
+        return [['probability=%f, class=%s' %(prob[i], self.labels[i]) for i in a[0:5]]]
+        
+    def handle(self, data, context):
+        """
+        Call preprocess, inference and post-process functions
+        :param data: input data
+        :param context: mms context
+        """
+        
+        model_input = self.preprocess(data)
+        model_out = self.inference(model_input)
+        return self.postprocess(model_out)
+
+_service = ModelHandler()
+
+
+def handle(data, context):
+    if not _service.initialized:
+        _service.initialize(context)
+
+    if data is None:
+        return None
+
+    return _service.handle(data, context)

--- a/advanced_functionality/multi_model_bring_your_own/multi_model_endpoint_bring_your_own.ipynb
+++ b/advanced_functionality/multi_model_bring_your_own/multi_model_endpoint_bring_your_own.ipynb
@@ -1,0 +1,561 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Amazon SageMaker Multi-Model Endpoints using Scikit Learn\n",
+    "With [Amazon SageMaker multi-model endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html), customers can create an endpoint that seamlessly hosts up to thousands of models. These endpoints are well suited to use cases where any one of a large number of models, which can be served from a common inference container, needs to be invokable on-demand and where it is acceptable for infrequently invoked models to incur some additional latency. For applications which require consistently low inference latency, a traditional endpoint is still the best choice.\n",
+    "\n",
+    "At a high level, Amazon SageMaker manages the loading and unloading of models for a multi-model endpoint, as they are needed. When an invocation request is made for a particular model, Amazon SageMaker routes the request to an instance assigned to that model, downloads the model artifacts from S3 onto that instance, and initiates loading of the model into the memory of the container. As soon as the loading is complete, Amazon SageMaker performs the requested invocation and returns the result. If the model is already loaded in memory on the selected instance, the downloading and loading steps are skipped and the invocation is performed immediately.\n",
+    "\n",
+    "For the inference container to serve multiple models in a multi-model endpoint, it must implement [additional APIs](https://docs.aws.amazon.com/sagemaker/latest/dg/build-multi-model-build-container.html) in order to load, list, get, unload and invoke specific models. This notebook demonstrates how to build your own inference container that implements these APIs.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### Contents\n",
+    "\n",
+    "1. [Introduction to Multi Model Server (MMS)](#Introduction-to-Multi-Model-Server-(MMS))\n",
+    "  1. [Handling Out Of Memory conditions](#Handling-Out-Of-Memory-conditions)\n",
+    "  1. [SageMaker Inference Toolkit](#SageMaker-Inference-Toolkit)\n",
+    "1. [Building and registering a container using MMS](#Building-and-registering-a-container-using-MMS)\n",
+    "1. [Set up the environment](#Set-up-the-environment)\n",
+    "1. [Upload model artifacts to S3](#Upload-model-artifacts-to-S3)\n",
+    "1. [Create a multi-model endpoint](#Create-a-multi-model-endpoint)\n",
+    "  1. [Import models into hosting](#Import-models-into-hosting)\n",
+    "  1. [Create endpoint configuration](#Create-endpoint-configuration)\n",
+    "  1. [Create endpoint](#Create-endpoint)\n",
+    "1. [Invoke models](#Invoke-models)\n",
+    "  1. [Add models to the endpoint](#Add-models-to-the-endpoint)\n",
+    "  1. [Updating a model](#Updating-a-model)\n",
+    "1. [(Optional) Delete the hosting resources](#(Optional)-Delete-the-hosting-resources)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction to Multi Model Server (MMS)\n",
+    "\n",
+    "[Multi Model Server](https://github.com/awslabs/multi-model-server) is an open source framework for serving machine learning models. It provides the HTTP frontend and model management capabilities required by multi-model endpoints to host multiple models within a single container, load models into and unload models out of the container dynamically, and performing inference on a specified loaded model.\n",
+    "\n",
+    "MMS supports a pluggable custom backend handler where you can implement your own algorithm. This example uses a handler that supports loading and inference for MXNet models, which we will inspect below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "!cat container/model_handler.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Of note are the `handle(data, context)` and `initialize(self, context)` methods.\n",
+    "\n",
+    "The `initialize` method will be called when a model is loaded into memory. In this example, it loads the model artifacts at `model_dir` into MXNet.\n",
+    "\n",
+    "The `handle` method will be called when invoking the model. In this example, it validates the input payload and then forwards the input to MXNet, returning the output.\n",
+    "\n",
+    "This handler class is instantiated for every model loaded into the container, so state in the handler is not shared across models.\n",
+    "\n",
+    "### Handling Out Of Memory conditions\n",
+    "If MXNet fails to load the model due to lack of memory, a `MemoryError` is raised. Any time a model cannot be loaded due to lack of memory or any other resource constraint, a `MemoryError` must be raised. MMS will interpret the `MemoryError`, and return a 507 HTTP status code to SageMaker, where SageMaker will initiate unloading unused models to reclaim resources so the requested model can be loaded.\n",
+    "\n",
+    "### SageMaker Inference Toolkit\n",
+    "MMS supports [various settings](https://github.com/awslabs/multi-model-server/blob/master/docker/advanced_settings.md#description-of-config-file-settings) for the frontend server it starts.\n",
+    "\n",
+    "[SageMaker Inference Toolkit](https://github.com/aws/sagemaker-inference-toolkit) is a library that bootstraps MMS in a way that is compatible with SageMaker multi-model endpoints, while still allowing you to tweak important performance parameters, such as the number of workers per model. The inference container in this example uses the Inference Toolkit to start MMS which can be seen in the __`container/dockerd-entrypoint.py`__ file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Building and registering a container using MMS\n",
+    "\n",
+    "The shell script below will build a Docker image which uses MMS as the front end (configured through SageMaker Inference Toolkit), and `container/model_handler.py` that we inspected above as the backend handler. It will then upload the image to an ECR repository in your account."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%sh\n",
+    "\n",
+    "# The name of our algorithm\n",
+    "algorithm_name=demo-sagemaker-multimodel\n",
+    "\n",
+    "cd container\n",
+    "\n",
+    "account=$(aws sts get-caller-identity --query Account --output text)\n",
+    "\n",
+    "# Get the region defined in the current configuration (default to us-west-2 if none defined)\n",
+    "region=$(aws configure get region)\n",
+    "region=${region:-us-west-2}\n",
+    "\n",
+    "fullname=\"${account}.dkr.ecr.${region}.amazonaws.com/${algorithm_name}:latest\"\n",
+    "\n",
+    "# If the repository doesn't exist in ECR, create it.\n",
+    "aws ecr describe-repositories --repository-names \"${algorithm_name}\" > /dev/null 2>&1\n",
+    "\n",
+    "if [ $? -ne 0 ]\n",
+    "then\n",
+    "    aws ecr create-repository --repository-name \"${algorithm_name}\" > /dev/null\n",
+    "fi\n",
+    "\n",
+    "# Get the login command from ECR and execute it directly\n",
+    "$(aws ecr get-login --region ${region} --no-include-email)\n",
+    "\n",
+    "# Build the docker image locally with the image name and then push it to ECR\n",
+    "# with the full name.\n",
+    "\n",
+    "docker build -q -t ${algorithm_name} .\n",
+    "docker tag ${algorithm_name} ${fullname}\n",
+    "\n",
+    "docker push ${fullname}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up the environment\n",
+    "Define the S3 bucket and prefix where the model artifacts that will be invokable by your multi-model endpoint will be located.\n",
+    "\n",
+    "Also define the IAM role that will give SageMaker access to the model artifacts and ECR image that was created above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -qU awscli boto3 sagemaker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "from sagemaker import get_execution_role\n",
+    "\n",
+    "sm_client = boto3.client(service_name='sagemaker')\n",
+    "runtime_sm_client = boto3.client(service_name='sagemaker-runtime')\n",
+    "\n",
+    "account_id = boto3.client('sts').get_caller_identity()['Account']\n",
+    "region = boto3.Session().region_name\n",
+    "\n",
+    "bucket = 'sagemaker-{}-{}'.format(region, account_id)\n",
+    "prefix = 'demo-multimodel-endpoint'\n",
+    "\n",
+    "role = get_execution_role()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Upload model artifacts to S3\n",
+    "In this example we will use pre-trained ResNet 18 and ResNet 152 models, both trained on the ImageNet datset. First we will download the models from MXNet's model zoo, and then upload them to S3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import mxnet as mx\n",
+    "import os\n",
+    "import tarfile\n",
+    "\n",
+    "model_path = 'http://data.mxnet.io/models/imagenet/'\n",
+    "\n",
+    "mx.test_utils.download(model_path+'resnet/18-layers/resnet-18-0000.params', None, 'data/resnet_18')\n",
+    "mx.test_utils.download(model_path+'resnet/18-layers/resnet-18-symbol.json', None, 'data/resnet_18')\n",
+    "mx.test_utils.download(model_path+'synset.txt', None, 'data/resnet_18')\n",
+    "\n",
+    "with open('data/resnet_18/resnet-18-shapes.json', 'w') as file:\n",
+    "    file.write('[{\"shape\": [1, 3, 224, 224], \"name\": \"data\"}]')\n",
+    "    \n",
+    "with tarfile.open('data/resnet_18.tar.gz', 'w:gz') as tar:\n",
+    "    tar.add('data/resnet_18', arcname='.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mx.test_utils.download(model_path+'resnet/152-layers/resnet-152-0000.params', None, 'data/resnet_152')\n",
+    "mx.test_utils.download(model_path+'resnet/152-layers/resnet-152-symbol.json', None, 'data/resnet_152')\n",
+    "mx.test_utils.download(model_path+'synset.txt', None, 'data/resnet_152')\n",
+    "\n",
+    "with open('data/resnet_152/resnet-152-shapes.json', 'w') as file:\n",
+    "    file.write('[{\"shape\": [1, 3, 224, 224], \"name\": \"data\"}]')\n",
+    "    \n",
+    "with tarfile.open('data/resnet_152.tar.gz', 'w:gz') as tar:\n",
+    "    tar.add('data/resnet_152', arcname='.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from botocore.client import ClientError\n",
+    "import os\n",
+    "\n",
+    "s3 = boto3.resource('s3')\n",
+    "try:\n",
+    "    s3.meta.client.head_bucket(Bucket=bucket)\n",
+    "except ClientError:\n",
+    "    s3.create_bucket(Bucket=bucket,\n",
+    "                     CreateBucketConfiguration={\n",
+    "                         'LocationConstraint': region\n",
+    "                     })\n",
+    "\n",
+    "models = {'resnet_18.tar.gz', 'resnet_152.tar.gz'}\n",
+    "\n",
+    "for model in models:\n",
+    "    key = os.path.join(prefix, model)\n",
+    "    with open('data/'+model, 'rb') as file_obj:\n",
+    "        s3.Bucket(bucket).Object(key).upload_fileobj(file_obj)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a multi-model endpoint\n",
+    "### Import models into hosting\n",
+    "When creating the Model entity for multi-model endpoints, the container's `ModelDataUrl` is the S3 prefix where the model artifacts that are invokable by the endpoint are located. The rest of the S3 path will be specified when invoking the model.\n",
+    "\n",
+    "The `Mode` of container is specified as `MultiModel` to signify that the container will host multiple models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from time import gmtime, strftime\n",
+    "\n",
+    "model_name = 'DEMO-MultiModelModel' + strftime(\"%Y-%m-%d-%H-%M-%S\", gmtime())\n",
+    "model_url = 'https://s3-{}.amazonaws.com/{}/{}/'.format(region, bucket, prefix)\n",
+    "container = '{}.dkr.ecr.{}.amazonaws.com/{}:latest'.format(account_id, region, 'demo-sagemaker-multimodel')\n",
+    "\n",
+    "print('Model name: ' + model_name)\n",
+    "print('Model data Url: ' + model_url)\n",
+    "print('Container image: ' + container)\n",
+    "\n",
+    "container = {\n",
+    "    'Image': container,\n",
+    "    'ModelDataUrl': model_url,\n",
+    "    'Mode': 'MultiModel'\n",
+    "}\n",
+    "\n",
+    "create_model_response = sm_client.create_model(\n",
+    "    ModelName = model_name,\n",
+    "    ExecutionRoleArn = role,\n",
+    "    Containers = [container])\n",
+    "\n",
+    "print(\"Model Arn: \" + create_model_response['ModelArn'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create endpoint configuration\n",
+    "Endpoint config creation works the same way it does as single model endpoints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "endpoint_config_name = 'DEMO-MultiModelEndpointConfig-' + strftime(\"%Y-%m-%d-%H-%M-%S\", gmtime())\n",
+    "print('Endpoint config name: ' + endpoint_config_name)\n",
+    "\n",
+    "create_endpoint_config_response = sm_client.create_endpoint_config(\n",
+    "    EndpointConfigName = endpoint_config_name,\n",
+    "    ProductionVariants=[{\n",
+    "        'InstanceType': 'ml.m5.xlarge',\n",
+    "        'InitialInstanceCount': 2,\n",
+    "        'InitialVariantWeight': 1,\n",
+    "        'ModelName': model_name,\n",
+    "        'VariantName': 'AllTraffic'}])\n",
+    "\n",
+    "print(\"Endpoint config Arn: \" + create_endpoint_config_response['EndpointConfigArn'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create endpoint\n",
+    "Similarly, endpoint creation works the same way as for single model endpoints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "endpoint_name = 'DEMO-MultiModelEndpoint-' + strftime(\"%Y-%m-%d-%H-%M-%S\", gmtime())\n",
+    "print('Endpoint name: ' + endpoint_name)\n",
+    "\n",
+    "create_endpoint_response = sm_client.create_endpoint(\n",
+    "    EndpointName=endpoint_name,\n",
+    "    EndpointConfigName=endpoint_config_name)\n",
+    "print('Endpoint Arn: ' + create_endpoint_response['EndpointArn'])\n",
+    "\n",
+    "resp = sm_client.describe_endpoint(EndpointName=endpoint_name)\n",
+    "status = resp['EndpointStatus']\n",
+    "print(\"Endpoint Status: \" + status)\n",
+    "\n",
+    "print('Waiting for {} endpoint to be in service...'.format(endpoint_name))\n",
+    "waiter = sm_client.get_waiter('endpoint_in_service')\n",
+    "waiter.wait(EndpointName=endpoint_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Invoke models\n",
+    "Now we invoke the models that we uploaded to S3 previously. The first invocation of a model may be slow, since behind the scenes, SageMaker is downloading the model artifacts from S3 to the instance and loading it into the container.\n",
+    "\n",
+    "First we will download an image of a cat as the payload to invoke the model, then call InvokeEndpoint to invoke the ResNet 18 model. The `TargetModel` field is concatenated with the S3 prefix specified in `ModelDataUrl` when creating the model, to generate the location of the model in S3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fname = mx.test_utils.download('https://github.com/dmlc/web-data/blob/master/mxnet/doc/tutorials/python/predict_image/cat.jpg?raw=true', 'cat.jpg')\n",
+    "\n",
+    "with open(fname, 'rb') as f:\n",
+    "    payload = f.read()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "import json\n",
+    "\n",
+    "response = runtime_sm_client.invoke_endpoint(\n",
+    "    EndpointName=endpoint_name,\n",
+    "    ContentType='application/x-image',\n",
+    "    TargetModel='resnet_18.tar.gz', # this is the rest of the S3 path where the model artifacts are located\n",
+    "    Body=payload)\n",
+    "\n",
+    "print(*json.loads(response['Body'].read()), sep = '\\n')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When we invoke the same ResNet 18 model a 2nd time, it is already downloaded to the instance and loaded in the container, so inference is faster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "response = runtime_sm_client.invoke_endpoint(\n",
+    "    EndpointName=endpoint_name,\n",
+    "    ContentType='application/x-image',\n",
+    "    TargetModel='resnet_18.tar.gz',\n",
+    "    Body=payload)\n",
+    "\n",
+    "print(*json.loads(response['Body'].read()), sep = '\\n')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Invoke another model\n",
+    "Exercising the power of a multi-model endpoint, we can specify a different model (resnet_152.tar.gz) as `TargetModel` and perform inference on it using the same endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "response = runtime_sm_client.invoke_endpoint(\n",
+    "    EndpointName=endpoint_name,\n",
+    "    ContentType='application/x-image',\n",
+    "    TargetModel='resnet_152.tar.gz',\n",
+    "    Body=payload)\n",
+    "\n",
+    "print(*json.loads(response['Body'].read()), sep = '\\n')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Add models to the endpoint\n",
+    "We can add more models to the endpoint without having to update the endpoint. Below we are adding a 3rd model, `squeezenet_v1.0`. To demonstrate hosting multiple models behind the endpoint, this model is duplicated 10 times with a slightly different name in S3. In a more realistic scenario, these could be 10 new different models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mx.test_utils.download(model_path+'squeezenet/squeezenet_v1.0-0000.params', None, 'data/squeezenet_v1.0')\n",
+    "mx.test_utils.download(model_path+'squeezenet/squeezenet_v1.0-symbol.json', None, 'data/squeezenet_v1.0')\n",
+    "mx.test_utils.download(model_path+'synset.txt', None, 'data/squeezenet_v1.0')\n",
+    "\n",
+    "with open('data/squeezenet_v1.0/squeezenet_v1.0-shapes.json', 'w') as file:\n",
+    "    file.write('[{\"shape\": [1, 3, 224, 224], \"name\": \"data\"}]')\n",
+    "    \n",
+    "with tarfile.open('data/squeezenet_v1.0.tar.gz', 'w:gz') as tar:\n",
+    "    tar.add('data/squeezenet_v1.0', arcname='.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file = 'data/squeezenet_v1.0.tar.gz'\n",
+    "\n",
+    "for x in range(0, 10):\n",
+    "    s3_file_name = 'demo-subfolder/squeezenet_v1.0_{}.tar.gz'.format(x)\n",
+    "    key = os.path.join(prefix, s3_file_name)\n",
+    "    with open(file, 'rb') as file_obj:\n",
+    "        s3.Bucket(bucket).Object(key).upload_fileobj(file_obj)\n",
+    "    models.add(s3_file_name)\n",
+    "\n",
+    "print('Number of models: {}'.format(len(models)))\n",
+    "print('Models: {}'.format(models))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After uploading the SqueezeNet models to S3, we will invoke the endpoint 100 times, randomly choosing from one of the 12 models behind the S3 prefix for each invocation, and keeping a count of the label with the highest probability on each invoke response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "import random\n",
+    "from collections import defaultdict\n",
+    "\n",
+    "results = defaultdict(int)\n",
+    "\n",
+    "for x in range(0, 100):\n",
+    "    target_model = random.choice(tuple(models))\n",
+    "    response = runtime_sm_client.invoke_endpoint(\n",
+    "        EndpointName=endpoint_name,\n",
+    "        ContentType='application/x-image',\n",
+    "        TargetModel=target_model,\n",
+    "        Body=payload)\n",
+    "\n",
+    "    results[json.loads(response['Body'].read())[0]] += 1\n",
+    "    \n",
+    "print(*results.items(), sep = '\\n')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Updating a model\n",
+    "To update a model, you would follow the same approach as above and add it as a new model. For example, if you have retrained the `resnet_18.tar.gz` model and wanted to start invoking it, you would upload the updated model artifacts behind the S3 prefix with a new name such as `resnet_18_v2.tar.gz`, and then change the `TargetModel` field to invoke `resnet_18_v2.tar.gz` instead of `resnet_18.tar.gz`. You do not want to overwrite the model artifacts in Amazon S3, because the old version of the model might still be loaded in the containers or on the storage volume of the instances on the endpoint. Invocations to the new model could then invoke the old version of the model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## (Optional) Delete the hosting resources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sm_client.delete_endpoint(EndpointName=endpoint_name)\n",
+    "sm_client.delete_endpoint_config(EndpointConfigName=endpoint_config_name)\n",
+    "sm_client.delete_model(ModelName=model_name)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_mxnet_p36",
+   "language": "python",
+   "name": "conda_mxnet_p36"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/advanced_functionality/multi_model_bring_your_own/multi_model_endpoint_bring_your_own.ipynb
+++ b/advanced_functionality/multi_model_bring_your_own/multi_model_endpoint_bring_your_own.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Amazon SageMaker Multi-Model Endpoints using Scikit Learn\n",
+    "# Amazon SageMaker Multi-Model Endpoints using your own algorithm container\n",
     "With [Amazon SageMaker multi-model endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html), customers can create an endpoint that seamlessly hosts up to thousands of models. These endpoints are well suited to use cases where any one of a large number of models, which can be served from a common inference container, needs to be invokable on-demand and where it is acceptable for infrequently invoked models to incur some additional latency. For applications which require consistently low inference latency, a traditional endpoint is still the best choice.\n",
     "\n",
     "At a high level, Amazon SageMaker manages the loading and unloading of models for a multi-model endpoint, as they are needed. When an invocation request is made for a particular model, Amazon SageMaker routes the request to an instance assigned to that model, downloads the model artifacts from S3 onto that instance, and initiates loading of the model into the memory of the container. As soon as the loading is complete, Amazon SageMaker performs the requested invocation and returns the result. If the model is already loaded in memory on the selected instance, the downloading and loading steps are skipped and the invocation is performed immediately.\n",

--- a/advanced_functionality/multi_model_sklearn_home_value/sklearn_multi_model_endpoint_home_value.ipynb
+++ b/advanced_functionality/multi_model_sklearn_home_value/sklearn_multi_model_endpoint_home_value.ipynb
@@ -1,0 +1,938 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Amazon SageMaker Multi-Model Endpoints using Scikit Learn\n",
+    "With [Amazon SageMaker multi-model endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html), customers can create an endpoint that seamlessly hosts up to thousands of models. These endpoints are well suited to use cases where any one of a large number of models, which can be served from a common inference container, needs to be invokable on-demand and where it is acceptable for infrequently invoked models to incur some additional latency. For applications which require consistently low inference latency, a traditional endpoint is still the best choice.\n",
+    "\n",
+    "At a high level, Amazon SageMaker manages the loading and unloading of models for a multi-model endpoint, as they are needed. When an invocation request is made for a particular model, Amazon SageMaker routes the request to an instance assigned to that model, downloads the model artifacts from S3 onto that instance, and initiates loading of the model into the memory of the container. As soon as the loading is complete, Amazon SageMaker performs the requested invocation and returns the result. If the model is already loaded in memory on the selected instance, the downloading and loading steps are skipped and the invocation is performed immediately.\n",
+    "\n",
+    "To demonstrate how multi-model endpoints are created and used, this notebook provides an example using a set of Scikit Learn models that each predict housing prices for a single location. This domain is used as a simple example to easily experiment with multi-model endpoints.\n",
+    "\n",
+    "The Amazon SageMaker multi-model endpoint capability is designed to work across all machine learning frameworks and algorithms including those where you bring your own container."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Contents\n",
+    "\n",
+    "1. [Build and register a Scikit Learn container that can serve multiple models](#Build-and-register-a-Scikit-Learn-container-that-can-serve-multiple-models)\n",
+    "1. [Generate synthetic data for housing models](#Generate-synthetic-data-for-housing-models)\n",
+    "1. [Train multiple house value prediction models](#Train-multiple-house-value-prediction-models)\n",
+    "1. [Import models into hosting](#Import-models-into-hosting)\n",
+    "  1. [Deploy model artifacts to be found by the endpoint](#Deploy-model-artifacts-to-be-found-by-the-endpoint)\n",
+    "  1. [Create the Amazon SageMaker model entity](#Create-the-Amazon-SageMaker-model-entity)\n",
+    "  1. [Create the multi-model endpoint](#Create-the-multi-model-endpoint)\n",
+    "1. [Exercise the multi-model endpoint](#Exercise-the-multi-model-endpoint)\n",
+    "  1. [Dynamically deploy another model](#Dynamically-deploy-another-model)\n",
+    "  1. [Invoke the newly deployed model](#Invoke-the-newly-deployed-model)\n",
+    "  1. [Updating a model](#Updating-a-model)\n",
+    "1. [Clean up](#Clean-up)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build and register a Scikit Learn container that can serve multiple models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -qU awscli boto3 sagemaker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the inference container to serve multiple models in a multi-model endpoint, it must implement [additional APIs](https://docs.aws.amazon.com/sagemaker/latest/dg/build-multi-model-build-container.html) in order to load, list, get, unload and invoke specific models.\n",
+    "\n",
+    "The ['mme' branch of the SageMaker Scikit Learn Container repository](https://github.com/aws/sagemaker-scikit-learn-container/tree/mme) is an example implementation on how to adapt SageMaker's Scikit Learn framework container to use [Multi Model Server](https://github.com/awslabs/multi-model-server), a framework that provides an HTTP frontend that implements the additional container APIs required by multi-model endpoints, and also provides a pluggable backend handler for serving models using a custom framework, in this case the Scikit Learn framework.\n",
+    "\n",
+    "Using this branch, below we will build a Scikit Learn container image that fulfills all of the multi-model endpoint container requirements, and then upload that image to Amazon Elastic Container Registry (ECR). Because uploading the image to ECR may create a new ECR repository, this notebook requires permissions in addition to the regular SageMakerFullAccess permissions. The easiest way to add these permissions is simply to add the managed policy AmazonEC2ContainerRegistryFullAccess to the role that you used to start your notebook instance. There's no need to restart your notebook instance when you do this, the new permissions will be available immediately."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ALGORITHM_NAME = 'multi-model-sklearn'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sh -s $ALGORITHM_NAME\n",
+    "\n",
+    "algorithm_name=$1\n",
+    "\n",
+    "account=$(aws sts get-caller-identity --query Account --output text)\n",
+    "\n",
+    "# Get the region defined in the current configuration (default to us-west-2 if none defined)\n",
+    "region=$(aws configure get region)\n",
+    "\n",
+    "ecr_image=\"${account}.dkr.ecr.${region}.amazonaws.com/${algorithm_name}:latest\"\n",
+    "\n",
+    "# If the repository doesn't exist in ECR, create it.\n",
+    "aws ecr describe-repositories --repository-names \"${algorithm_name}\" > /dev/null 2>&1\n",
+    "\n",
+    "if [ $? -ne 0 ]\n",
+    "then\n",
+    "    aws ecr create-repository --repository-name \"${algorithm_name}\" > /dev/null\n",
+    "fi\n",
+    "\n",
+    "# Get the login command from ECR and execute it directly\n",
+    "$(aws ecr get-login --region ${region} --no-include-email --registry-ids ${account})\n",
+    "\n",
+    "# Build the docker image locally with the image name and then push it to ECR\n",
+    "# with the full image name.\n",
+    "\n",
+    "# First clear out any prior version of the cloned repo\n",
+    "rm -rf sagemaker-scikit-learn-container/\n",
+    "\n",
+    "# Clone the sklearn container repo\n",
+    "git clone --single-branch --branch mme https://github.com/aws/sagemaker-scikit-learn-container.git\n",
+    "cd sagemaker-scikit-learn-container/\n",
+    "\n",
+    "# Build the \"base\" container image that encompasses the installation of the\n",
+    "# scikit-learn framework and all of the dependencies needed.\n",
+    "docker build -q -t sklearn-base:0.20-2-cpu-py3 -f docker/0.20-2/base/Dockerfile.cpu --build-arg py_version=3 .\n",
+    "\n",
+    "# Create the SageMaker Scikit-learn Container Python package.\n",
+    "python setup.py bdist_wheel --universal\n",
+    "\n",
+    "# Build the \"final\" container image that encompasses the installation of the\n",
+    "# code that implements the SageMaker multi-model container requirements.\n",
+    "docker build -q -t ${algorithm_name} -f docker/0.20-2/final/Dockerfile.cpu .\n",
+    "\n",
+    "docker tag ${algorithm_name} ${ecr_image}\n",
+    "\n",
+    "docker push ${ecr_image}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate synthetic data for housing models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import json\n",
+    "import datetime\n",
+    "import time\n",
+    "from time import gmtime, strftime\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NUM_HOUSES_PER_LOCATION = 1000\n",
+    "LOCATIONS  = ['NewYork_NY',    'LosAngeles_CA',   'Chicago_IL',    'Houston_TX',   'Dallas_TX',\n",
+    "              'Phoenix_AZ',    'Philadelphia_PA', 'SanAntonio_TX', 'SanDiego_CA',  'SanFrancisco_CA']\n",
+    "PARALLEL_TRAINING_JOBS = 4 # len(LOCATIONS) if your account limits can handle it\n",
+    "MAX_YEAR = 2019"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def gen_price(house):\n",
+    "    _base_price = int(house['SQUARE_FEET'] * 150)\n",
+    "    _price = int(_base_price + (10000 * house['NUM_BEDROOMS']) + \\\n",
+    "                               (15000 * house['NUM_BATHROOMS']) + \\\n",
+    "                               (15000 * house['LOT_ACRES']) + \\\n",
+    "                               (15000 * house['GARAGE_SPACES']) - \\\n",
+    "                               (5000 * (MAX_YEAR - house['YEAR_BUILT'])))\n",
+    "    return _price"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def gen_random_house():\n",
+    "    _house = {'SQUARE_FEET':   int(np.random.normal(3000, 750)),\n",
+    "              'NUM_BEDROOMS':  np.random.randint(2, 7),\n",
+    "              'NUM_BATHROOMS': np.random.randint(2, 7) / 2,\n",
+    "              'LOT_ACRES':     round(np.random.normal(1.0, 0.25), 2),\n",
+    "              'GARAGE_SPACES': np.random.randint(0, 4),\n",
+    "              'YEAR_BUILT':    min(MAX_YEAR, int(np.random.normal(1995, 10)))}\n",
+    "    _price = gen_price(_house)\n",
+    "    return [_price, _house['YEAR_BUILT'],   _house['SQUARE_FEET'], \n",
+    "                    _house['NUM_BEDROOMS'], _house['NUM_BATHROOMS'], \n",
+    "                    _house['LOT_ACRES'],    _house['GARAGE_SPACES']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "COLUMNS = ['PRICE', 'YEAR_BUILT', 'SQUARE_FEET', 'NUM_BEDROOMS',\n",
+    "           'NUM_BATHROOMS', 'LOT_ACRES', 'GARAGE_SPACES']\n",
+    "def gen_houses(num_houses):\n",
+    "    _house_list = []\n",
+    "    for i in range(num_houses):\n",
+    "        _house_list.append(gen_random_house())\n",
+    "    _df = pd.DataFrame(_house_list, \n",
+    "                       columns=COLUMNS)\n",
+    "    return _df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train multiple house value prediction models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sagemaker\n",
+    "from sagemaker import get_execution_role\n",
+    "from sagemaker.predictor import csv_serializer\n",
+    "import boto3\n",
+    "\n",
+    "sm_client = boto3.client(service_name='sagemaker')\n",
+    "runtime_sm_client = boto3.client(service_name='sagemaker-runtime')\n",
+    "\n",
+    "s3 = boto3.resource('s3')\n",
+    "s3_client = boto3.client('s3')\n",
+    "\n",
+    "sagemaker_session = sagemaker.Session()\n",
+    "role = get_execution_role()\n",
+    "\n",
+    "ACCOUNT_ID  = boto3.client('sts').get_caller_identity()['Account']\n",
+    "REGION      = boto3.Session().region_name\n",
+    "BUCKET      = sagemaker_session.default_bucket()\n",
+    "SCRIPT_FILENAME     = 'script.py'\n",
+    "USER_CODE_ARTIFACTS = 'user_code.tar.gz'\n",
+    "\n",
+    "MULTI_MODEL_SKLEARN_IMAGE = '{}.dkr.ecr.{}.amazonaws.com/{}:latest'.format(ACCOUNT_ID, REGION, \n",
+    "                                                                           ALGORITHM_NAME)\n",
+    "\n",
+    "DATA_PREFIX            = 'DEMO_MME_SCIKIT'\n",
+    "HOUSING_MODEL_NAME     = 'housing'\n",
+    "MULTI_MODEL_ARTIFACTS  = 'multi_model_artifacts'\n",
+    "\n",
+    "TRAIN_INSTANCE_TYPE    = 'ml.m4.xlarge'\n",
+    "ENDPOINT_INSTANCE_TYPE = 'ml.m4.xlarge'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Split a given dataset into train, validation, and test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.model_selection import train_test_split\n",
+    "SEED = 7\n",
+    "SPLIT_RATIOS = [0.6, 0.3, 0.1]\n",
+    "\n",
+    "def split_data(df):\n",
+    "    # split data into train and test sets\n",
+    "    seed      = SEED\n",
+    "    val_size  = SPLIT_RATIOS[1]\n",
+    "    test_size = SPLIT_RATIOS[2]\n",
+    "    \n",
+    "    num_samples = df.shape[0]\n",
+    "    X1 = df.values[:num_samples, 1:] # keep only the features, skip the target, all rows\n",
+    "    Y1 = df.values[:num_samples, :1] # keep only the target, all rows\n",
+    "\n",
+    "    # Use split ratios to divide up into train/val/test\n",
+    "    X_train, X_val, y_train, y_val = \\\n",
+    "        train_test_split(X1, Y1, test_size=(test_size + val_size), random_state=seed)\n",
+    "    # Of the remaining non-training samples, give proper ratio to validation and to test\n",
+    "    X_test, X_test, y_test, y_test = \\\n",
+    "        train_test_split(X_val, y_val, test_size=(test_size / (test_size + val_size)), \n",
+    "                         random_state=seed)\n",
+    "    # reassemble the datasets with target in first column and features after that\n",
+    "    _train = np.concatenate([y_train, X_train], axis=1)\n",
+    "    _val   = np.concatenate([y_val,   X_val],   axis=1)\n",
+    "    _test  = np.concatenate([y_test,  X_test],  axis=1)\n",
+    "\n",
+    "    return _train, _val, _test"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Launch a single training job for a given housing location\n",
+    "There is nothing specific to multi-model endpoints in terms of the models it will host. They are trained in the same way as all other SageMaker models. Here we are using the Scikit Learn estimator and not waiting for the job to complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile $SCRIPT_FILENAME\n",
+    "\n",
+    "import argparse\n",
+    "import os\n",
+    "import glob\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sklearn.ensemble import RandomForestRegressor\n",
+    "from sklearn.externals import joblib\n",
+    "\n",
+    "# inference functions ---------------\n",
+    "def model_fn(model_dir):\n",
+    "    print('loading model.joblib from: {}'.format(model_dir))\n",
+    "    _loaded_model = joblib.load(os.path.join(model_dir, 'model.joblib'))\n",
+    "    return _loaded_model\n",
+    "\n",
+    "\n",
+    "if __name__ =='__main__':\n",
+    "\n",
+    "    print('extracting arguments')\n",
+    "    parser = argparse.ArgumentParser()\n",
+    "\n",
+    "    # hyperparameters sent by the client are passed as command-line arguments to the script.\n",
+    "    # to simplify the demo we don't use all sklearn RandomForest hyperparameters\n",
+    "    parser.add_argument('--n-estimators', type=int, default=10)\n",
+    "    parser.add_argument('--min-samples-leaf', type=int, default=3)\n",
+    "\n",
+    "    # Data, model, and output directories\n",
+    "    parser.add_argument('--model-dir', type=str, default=os.environ.get('SM_MODEL_DIR'))\n",
+    "    parser.add_argument('--train', type=str, default=os.environ.get('SM_CHANNEL_TRAIN'))\n",
+    "    parser.add_argument('--validation', type=str, default=os.environ.get('SM_CHANNEL_VALIDATION'))\n",
+    "    parser.add_argument('--model-name', type=str)\n",
+    "\n",
+    "    args, _ = parser.parse_known_args()\n",
+    "\n",
+    "    print('reading data')\n",
+    "    print('model_name: {}'.format(args.model_name))\n",
+    "\n",
+    "    train_file = os.path.join(args.train, args.model_name + '_train.csv')    \n",
+    "    train_df = pd.read_csv(train_file)\n",
+    "\n",
+    "    val_file = os.path.join(args.validation, args.model_name + '_val.csv')\n",
+    "    test_df = pd.read_csv(os.path.join(val_file))\n",
+    "\n",
+    "    print('building training and testing datasets')\n",
+    "    X_train = train_df[train_df.columns[1:train_df.shape[1]]] \n",
+    "    X_test = test_df[test_df.columns[1:test_df.shape[1]]]\n",
+    "    y_train = train_df[train_df.columns[0]]\n",
+    "    y_test = test_df[test_df.columns[0]]\n",
+    "\n",
+    "    # train\n",
+    "    print('training model')\n",
+    "    model = RandomForestRegressor(\n",
+    "        n_estimators=args.n_estimators,\n",
+    "        min_samples_leaf=args.min_samples_leaf,\n",
+    "        n_jobs=-1)\n",
+    "    \n",
+    "    model.fit(X_train, y_train)\n",
+    "\n",
+    "    # print abs error\n",
+    "    print('validating model')\n",
+    "    abs_err = np.abs(model.predict(X_test) - y_test)\n",
+    "\n",
+    "    # print couple perf metrics\n",
+    "    for q in [10, 50, 90]:\n",
+    "        print('AE-at-' + str(q) + 'th-percentile: '\n",
+    "              + str(np.percentile(a=abs_err, q=q)))\n",
+    "        \n",
+    "    # persist model\n",
+    "    path = os.path.join(args.model_dir, 'model.joblib')\n",
+    "    joblib.dump(model, path)\n",
+    "    print('model persisted at ' + path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#  can test the model locally \n",
+    "# ! python script.py --n-estimators 100 \\\n",
+    "#                    --min-samples-leaf 2 \\\n",
+    "#                    --model-dir ./ \\\n",
+    "#                    --model-name 'NewYork_NY' \\\n",
+    "#                    --train ./data/NewYork_NY/train/ \\\n",
+    "#                    --validation ./data/NewYork_NY/val/\n",
+    "# from sklearn.externals import joblib\n",
+    "# regr = joblib.load('./model.joblib')\n",
+    "# _start_time = time.time()\n",
+    "# regr.predict([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0]])\n",
+    "# _duration = time.time() - _start_time\n",
+    "# print('took {:,d} ms'.format(int(_duration * 1000)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.sklearn.estimator import SKLearn\n",
+    "\n",
+    "def launch_training_job(location):\n",
+    "    # clear out old versions of the data\n",
+    "    _s3_bucket = s3.Bucket(BUCKET)\n",
+    "    _full_input_prefix = '{}/model_prep/{}'.format(DATA_PREFIX, location)\n",
+    "    _s3_bucket.objects.filter(Prefix=_full_input_prefix + '/').delete()\n",
+    "\n",
+    "    # upload the entire set of data for all three channels\n",
+    "    _local_folder = 'data/{}'.format(location)\n",
+    "    _inputs = sagemaker_session.upload_data(path=_local_folder, \n",
+    "                                            key_prefix=_full_input_prefix)\n",
+    "    print('Training data uploaded: {}'.format(_inputs))\n",
+    "    \n",
+    "    _job = 'mme-{}'.format(location.replace('_', '-'))\n",
+    "    _full_output_prefix = '{}/model_artifacts/{}'.format(DATA_PREFIX, \n",
+    "                                                        location)\n",
+    "    _s3_output_path = 's3://{}/{}'.format(BUCKET, _full_output_prefix)\n",
+    "\n",
+    "    _estimator = SKLearn(\n",
+    "         entry_point=SCRIPT_FILENAME, role=role,\n",
+    "         train_instance_count=1, train_instance_type=TRAIN_INSTANCE_TYPE,\n",
+    "         framework_version='0.20.0',\n",
+    "         output_path=_s3_output_path,\n",
+    "         base_job_name=_job,\n",
+    "         metric_definitions=[\n",
+    "             {'Name' : 'median-AE',\n",
+    "              'Regex': 'AE-at-50th-percentile: ([0-9.]+).*$'}],\n",
+    "         hyperparameters = {'n-estimators'    : 100,\n",
+    "                            'min-samples-leaf': 3,\n",
+    "                            'model-name'      : location})\n",
+    "    \n",
+    "    DISTRIBUTION_MODE = 'FullyReplicated'\n",
+    "    _train_input = sagemaker.s3_input(s3_data=_inputs+'/train', \n",
+    "                                      distribution=DISTRIBUTION_MODE, content_type='csv')\n",
+    "    _val_input   = sagemaker.s3_input(s3_data=_inputs+'/val', \n",
+    "                                      distribution=DISTRIBUTION_MODE, content_type='csv')\n",
+    "    _remote_inputs = {'train': _train_input, 'validation': _val_input}\n",
+    "\n",
+    "    _estimator.fit(_remote_inputs, wait=False)\n",
+    "    \n",
+    "    return _estimator.latest_training_job.name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Kick off a model training job for each housing location"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def save_data_locally(location, train, val, test):\n",
+    "    _header = ','.join(COLUMNS)\n",
+    "    \n",
+    "    os.makedirs('data/{}/train'.format(location))\n",
+    "    np.savetxt( 'data/{0}/train/{0}_train.csv'.format(location), train, delimiter=',', fmt='%.2f')\n",
+    "    \n",
+    "    os.makedirs('data/{}/val'.format(location))\n",
+    "    np.savetxt( 'data/{0}/val/{0}_val.csv'.format(location),     val,   delimiter=',', fmt='%.2f')\n",
+    "    \n",
+    "    os.makedirs('data/{}/test'.format(location))\n",
+    "    np.savetxt( 'data/{0}/test/{0}_test.csv'.format(location),   test,  delimiter=',', fmt='%.2f')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "import os\n",
+    "\n",
+    "training_jobs = []\n",
+    "\n",
+    "shutil.rmtree('data', ignore_errors=True)\n",
+    "\n",
+    "for loc in LOCATIONS[:PARALLEL_TRAINING_JOBS]:\n",
+    "    _houses = gen_houses(NUM_HOUSES_PER_LOCATION)\n",
+    "    _train, _val, _test = split_data(_houses)\n",
+    "    save_data_locally(loc, _train, _val, _test)\n",
+    "    _job = launch_training_job(loc)\n",
+    "    training_jobs.append(_job)\n",
+    "print('{} training jobs launched: {}'.format(len(training_jobs), training_jobs))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Wait for all model training to finish"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def wait_for_training_job_to_complete(job_name):\n",
+    "    print('Waiting for job {} to complete...'.format(job_name))\n",
+    "    _resp   = sm_client.describe_training_job(TrainingJobName=job_name)\n",
+    "    _status = _resp['TrainingJobStatus']\n",
+    "    while _status=='InProgress':\n",
+    "        time.sleep(60)\n",
+    "        _resp   = sm_client.describe_training_job(TrainingJobName=job_name)\n",
+    "        _status = _resp['TrainingJobStatus']\n",
+    "        if _status == 'InProgress':\n",
+    "            print('{} job status: {}'.format(job_name, _status))\n",
+    "    print('DONE. Status for {} is {}\\n'.format(job_name, _status))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# wait for the jobs to finish\n",
+    "for j in training_jobs:\n",
+    "    wait_for_training_job_to_complete(j)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import models into hosting\n",
+    "When creating the Model entity for a multi-model endpoint, the `ModelDataUrl` of the ContainerDefinition is treated as an S3 prefix for the model artifacts that will be loaded on-demand. The rest of the S3 path will be specified in the `InvokeEndpoint` request. Remember to close the location with a trailing slash.\n",
+    "\n",
+    "The `Mode` of container is specified as `MultiModel` to signify that the container will host multiple models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Deploy model artifacts to be found by the endpoint\n",
+    "As described above, the multi-model endpoint is configured to find its model artifacts in a specific location in S3. For each trained model, we make a copy of its model artifacts into that location.\n",
+    "\n",
+    "In our example, we are storing all the models within a single folder. The implementation of multi-model endpoints is flexible enough to permit an arbitrary folder structure. For a set of housing models for example, you could have a top level folder for each region, and the model artifacts would be copied to those regional folders. The target model referenced when invoking such a model would include the folder path. For example, `northeast/Boston_MA.tar.gz`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "def parse_model_artifacts(model_data_url):\n",
+    "    # extract the s3 key from the full url to the model artifacts\n",
+    "    _s3_key = model_data_url.split('s3://{}/'.format(BUCKET))[1]\n",
+    "    # get the part of the key that identifies the model within the model artifacts folder\n",
+    "    _model_name_plus = _s3_key[_s3_key.find('model_artifacts') + len('model_artifacts') + 1:]\n",
+    "    # finally, get the unique model name (e.g., \"NewYork_NY\")\n",
+    "    _model_name = re.findall('^(.*?)/', _model_name_plus)[0]\n",
+    "    return _s3_key, _model_name "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# make a copy of the model artifacts from the original output of the training job to the place in\n",
+    "# s3 where the multi model endpoint will dynamically load individual models\n",
+    "def deploy_artifacts_to_mme(job_name):\n",
+    "    _resp = sm_client.describe_training_job(TrainingJobName=job_name)\n",
+    "    _source_s3_key, _model_name = parse_model_artifacts(_resp['ModelArtifacts']['S3ModelArtifacts'])\n",
+    "    _copy_source = {'Bucket': BUCKET, 'Key': _source_s3_key}\n",
+    "    _key = '{}/{}/{}.tar.gz'.format(DATA_PREFIX, MULTI_MODEL_ARTIFACTS, _model_name)\n",
+    "    \n",
+    "    print('Copying {} model\\n   from: {}\\n     to: {}...'.format(_model_name, _source_s3_key, _key))\n",
+    "    s3_client.copy_object(Bucket=BUCKET, CopySource=_copy_source, Key=_key)\n",
+    "    return _key"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that we are purposely *not* copying the first model. This will be copied later in the notebook to demonstrate how to dynamically add new models to an already running endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First, clear out old versions of the model artifacts from previous runs of this notebook\n",
+    "s3 = boto3.resource('s3')\n",
+    "s3_bucket = s3.Bucket(BUCKET)\n",
+    "full_input_prefix = '{}/multi_model_artifacts'.format(DATA_PREFIX)\n",
+    "print('Removing old model artifacts from {}'.format(full_input_prefix))\n",
+    "filter_resp = s3_bucket.objects.filter(Prefix=full_input_prefix + '/').delete()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# copy every model except the first one\n",
+    "for job in training_jobs[1:]:\n",
+    "    deploy_artifacts_to_mme(job)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create the Amazon SageMaker model entity\n",
+    "Here we use `boto3` to create the model entity. Instead of describing a single model, it will indicate the use of multi-model semantics and will identify the source location of all specific model artifacts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# When using multi-model endpoints with the Scikit Learn container, we need to provide an entry point for\n",
+    "# inference that will at least load the saved model. This function uploads a model artifact containing such a\n",
+    "# script. This tar.gz file will be fed to the SageMaker multi-model creation and pointed to by the \n",
+    "# SAGEMAKER_SUBMIT_DIRECTORY environment variable.\n",
+    "\n",
+    "def upload_inference_code(script_file_name, prefix):\n",
+    "    _tmp_folder = 'inference-code'\n",
+    "    if not os.path.exists(_tmp_folder):\n",
+    "        os.makedirs(_tmp_folder)\n",
+    "    !tar -czvf $_tmp_folder/$USER_CODE_ARTIFACTS $script_file_name > /dev/null\n",
+    "    _loc = sagemaker_session.upload_data(_tmp_folder, \n",
+    "                                         key_prefix='{}/{}'.format(prefix, _tmp_folder))\n",
+    "    return _loc + '/' + USER_CODE_ARTIFACTS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_multi_model_entity(multi_model_name, role):\n",
+    "    # establish the place in S3 from which the endpoint will pull individual models\n",
+    "    _model_url  = 's3://{}/{}/{}/'.format(BUCKET, DATA_PREFIX, MULTI_MODEL_ARTIFACTS)\n",
+    "    _container = {\n",
+    "        'Image':        MULTI_MODEL_SKLEARN_IMAGE,\n",
+    "        'ModelDataUrl': _model_url,\n",
+    "        'Mode':         'MultiModel',\n",
+    "        'Environment': {\n",
+    "            'SAGEMAKER_PROGRAM' : SCRIPT_FILENAME,\n",
+    "            'SAGEMAKER_SUBMIT_DIRECTORY' : upload_inference_code(SCRIPT_FILENAME, DATA_PREFIX)\n",
+    "        }\n",
+    "    }\n",
+    "    create_model_response = sm_client.create_model(\n",
+    "        ModelName = multi_model_name,\n",
+    "        ExecutionRoleArn = role,\n",
+    "        Containers = [_container])\n",
+    "    \n",
+    "    return _model_url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_model_name = '{}-{}'.format(HOUSING_MODEL_NAME, strftime('%Y-%m-%d-%H-%M-%S', gmtime()))\n",
+    "model_url = create_multi_model_entity(multi_model_name, role)\n",
+    "print('Multi model name: {}'.format(multi_model_name))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Here are the models that the endpoint has at its disposal:')\n",
+    "!aws s3 ls --human-readable --summarize $model_url"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create the multi-model endpoint\n",
+    "There is nothing special about the SageMaker endpoint config for a multi-model endpoint. You need to consider the appropriate instance type and number of instances for the projected prediction workload. The number and size of the individual models will drive memory requirements.\n",
+    "\n",
+    "Once the endpoint config is in place, the endpoint creation is straightforward."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "endpoint_config_name = multi_model_name\n",
+    "print('Endpoint config name: ' + endpoint_config_name)\n",
+    "\n",
+    "create_endpoint_config_response = sm_client.create_endpoint_config(\n",
+    "    EndpointConfigName = endpoint_config_name,\n",
+    "    ProductionVariants=[{\n",
+    "        'InstanceType': ENDPOINT_INSTANCE_TYPE,\n",
+    "        'InitialInstanceCount': 1,\n",
+    "        'InitialVariantWeight': 1,\n",
+    "        'ModelName'   : multi_model_name,\n",
+    "        'VariantName' : 'AllTraffic'}])\n",
+    "\n",
+    "endpoint_name = multi_model_name\n",
+    "print('Endpoint name: ' + endpoint_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_endpoint_response = sm_client.create_endpoint(\n",
+    "    EndpointName=endpoint_name,\n",
+    "    EndpointConfigName=endpoint_config_name)\n",
+    "print('Endpoint Arn: ' + create_endpoint_response['EndpointArn'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Waiting for {} endpoint to be in service...'.format(endpoint_name))\n",
+    "waiter = sm_client.get_waiter('endpoint_in_service')\n",
+    "waiter.wait(EndpointName=endpoint_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercise the multi-model endpoint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Invoke multiple individual models hosted behind a single endpoint\n",
+    "Here we iterate through a set of housing predictions, choosing the specific location-based housing model at random. Notice the cold start price paid for the first invocation of any given model. Subsequent invocations of the same model take advantage of the model already being loaded into memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def predict_one_house_value(features, model_name):\n",
+    "    print('Using model {} to predict price of this house: {}'.format(full_model_name,\n",
+    "                                                                     features))\n",
+    "\n",
+    "    _float_features = [float(i) for i in features]\n",
+    "    _body = ','.join(map(str, _float_features)) + '\\n'\n",
+    "    \n",
+    "    _start_time = time.time()\n",
+    "\n",
+    "    _response = runtime_sm_client.invoke_endpoint(\n",
+    "                        EndpointName=endpoint_name,\n",
+    "                        ContentType='text/csv',\n",
+    "                        TargetModel=full_model_name,\n",
+    "                        Body=_body)\n",
+    "    _predicted_value = json.loads(_response['Body'].read())[0]\n",
+    "\n",
+    "    _duration = time.time() - _start_time\n",
+    "    \n",
+    "    print('${:,.2f}, took {:,d} ms\\n'.format(_predicted_value, int(_duration * 1000)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# iterate through invocations with random inputs against a random model showing results and latency\n",
+    "for i in range(10):\n",
+    "    model_name = LOCATIONS[np.random.randint(1, len(LOCATIONS[:PARALLEL_TRAINING_JOBS]))]\n",
+    "    full_model_name = '{}.tar.gz'.format(model_name)\n",
+    "    predict_one_house_value(gen_random_house()[1:], full_model_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Dynamically deploy another model\n",
+    "Here we demonstrate the power of dynamic loading of new models. We purposely did not copy the first model when deploying models earlier. Now we deploy an additional model and can immediately invoke it through the multi-model endpoint. As with the earlier models, the first invocation to the new model takes longer, as the endpoint takes time to download the model and load it into memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add another model to the endpoint and exercise it\n",
+    "deploy_artifacts_to_mme(training_jobs[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Invoke the newly deployed model\n",
+    "Exercise the newly deployed model without the need for any endpoint update or restart."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Here are the models that the endpoint has at its disposal:')\n",
+    "!aws s3 ls $model_url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_name = LOCATIONS[0]\n",
+    "full_model_name = '{}.tar.gz'.format(model_name)\n",
+    "for i in range(5):\n",
+    "    features = gen_random_house()\n",
+    "    predict_one_house_value(gen_random_house()[1:], full_model_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Updating a model\n",
+    "To update a model, you would follow the same approach as above and add it as a new model. For example, if you have retrained the `NewYork_NY.tar.gz` model and wanted to start invoking it, you would upload the updated model artifacts behind the S3 prefix with a new name such as `NewYork_NY_v2.tar.gz`, and then change the `TargetModel` field to invoke `NewYork_NY_v2.tar.gz` instead of `NewYork_NY.tar.gz`. You do not want to overwrite the model artifacts in Amazon S3, because the old version of the model might still be loaded in the containers or on the storage volume of the instances on the endpoint. Invocations to the new model could then invoke the old version of the model.\n",
+    "\n",
+    "Alternatively, you could stop the endpoint and re-deploy a fresh set of models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Clean up\n",
+    "Here, to be sure we are not billed for endpoints we are no longer using, we clean up."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# shut down the endpoint\n",
+    "sm_client.delete_endpoint(EndpointName=endpoint_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# and the endpoint config\n",
+    "sm_client.delete_endpoint_config(EndpointConfigName=endpoint_config_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# delete model too\n",
+    "sm_client.delete_model(ModelName=multi_model_name)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_python3",
+   "language": "python",
+   "name": "conda_python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/advanced_functionality/multi_model_xgboost_home_value/xgboost_multi_model_endpoint_home_value.ipynb
+++ b/advanced_functionality/multi_model_xgboost_home_value/xgboost_multi_model_endpoint_home_value.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Amazon SageMaker Multi-Model Endpoints using Scikit Learn\n",
+    "# Amazon SageMaker Multi-Model Endpoints using XGBoost\n",
     "With [Amazon SageMaker multi-model endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html), customers can create an endpoint that seamlessly hosts up to thousands of models. These endpoints are well suited to use cases where any one of a large number of models, which can be served from a common inference container, needs to be invokable on-demand and where it is acceptable for infrequently invoked models to incur some additional latency. For applications which require consistently low inference latency, a traditional endpoint is still the best choice.\n",
     "\n",
     "At a high level, Amazon SageMaker manages the loading and unloading of models for a multi-model endpoint, as they are needed. When an invocation request is made for a particular model, Amazon SageMaker routes the request to an instance assigned to that model, downloads the model artifacts from S3 onto that instance, and initiates loading of the model into the memory of the container. As soon as the loading is complete, Amazon SageMaker performs the requested invocation and returns the result. If the model is already loaded in memory on the selected instance, the downloading and loading steps are skipped and the invocation is performed immediately.\n",

--- a/advanced_functionality/multi_model_xgboost_home_value/xgboost_multi_model_endpoint_home_value.ipynb
+++ b/advanced_functionality/multi_model_xgboost_home_value/xgboost_multi_model_endpoint_home_value.ipynb
@@ -1,0 +1,793 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Amazon SageMaker Multi-Model Endpoints using Scikit Learn\n",
+    "With [Amazon SageMaker multi-model endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/multi-model-endpoints.html), customers can create an endpoint that seamlessly hosts up to thousands of models. These endpoints are well suited to use cases where any one of a large number of models, which can be served from a common inference container, needs to be invokable on-demand and where it is acceptable for infrequently invoked models to incur some additional latency. For applications which require consistently low inference latency, a traditional endpoint is still the best choice.\n",
+    "\n",
+    "At a high level, Amazon SageMaker manages the loading and unloading of models for a multi-model endpoint, as they are needed. When an invocation request is made for a particular model, Amazon SageMaker routes the request to an instance assigned to that model, downloads the model artifacts from S3 onto that instance, and initiates loading of the model into the memory of the container. As soon as the loading is complete, Amazon SageMaker performs the requested invocation and returns the result. If the model is already loaded in memory on the selected instance, the downloading and loading steps are skipped and the invocation is performed immediately.\n",
+    "\n",
+    "To demonstrate how multi-model endpoints are created and used, this notebook provides an example using a set of XGBoost models that each predict housing prices for a single location. This domain is used as a simple example to easily experiment with multi-model endpoints.\n",
+    "\n",
+    "The Amazon SageMaker multi-model endpoint capability is designed to work across all machine learning frameworks and algorithms including those where you bring your own container."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Contents\n",
+    "\n",
+    "1. [Build and register an XGBoost container that can serve multiple models](#Build-and-register-an-XGBoost-container-that-can-serve-multiple-models)\n",
+    "1. [Generate synthetic data for housing models](#Generate-synthetic-data-for-housing-models)\n",
+    "1. [Train multiple house value prediction models](#Train-multiple-house-value-prediction-models)\n",
+    "1. [Import models into hosting](#Import-models-into-hosting)\n",
+    "  1. [Deploy model artifacts to be found by the endpoint](#Deploy-model-artifacts-to-be-found-by-the-endpoint)\n",
+    "  1. [Create the Amazon SageMaker model entity](#Create-the-Amazon-SageMaker-model-entity)\n",
+    "  1. [Create the multi-model endpoint](#Create-the-multi-model-endpoint)\n",
+    "1. [Exercise the multi-model endpoint](#Exercise-the-multi-model-endpoint)\n",
+    "  1. [Dynamically deploy another model](#Dynamically-deploy-another-model)\n",
+    "  1. [Invoke the newly deployed model](#Invoke-the-newly-deployed-model)\n",
+    "  1. [Updating a model](#Updating-a-model)\n",
+    "1. [Clean up](#Clean-up)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build and register an XGBoost container that can serve multiple models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -qU awscli boto3 sagemaker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the inference container to serve multiple models in a multi-model endpoint, it must implement [additional APIs](https://docs.aws.amazon.com/sagemaker/latest/dg/build-multi-model-build-container.html) in order to load, list, get, unload and invoke specific models.\n",
+    "\n",
+    "The ['mme' branch of the SageMaker XGBoost Container repository](https://github.com/aws/sagemaker-xgboost-container/tree/mme) is an example implementation on how to adapt SageMaker's XGBoost framework container to use [Multi Model Server](https://github.com/awslabs/multi-model-server), a framework that provides an HTTP frontend that implements the additional container APIs required by multi-model endpoints, and also provides a pluggable backend handler for serving models using a custom framework, in this case the XGBoost framework.\n",
+    "\n",
+    "Using this branch, below we will build an XGBoost container that fulfills all of the multi-model endpoint container requirements, and then upload that image to Amazon Elastic Container Registry (ECR). Because uploading the image to ECR may create a new ECR repository, this notebook requires permissions in addition to the regular SageMakerFullAccess permissions. The easiest way to add these permissions is simply to add the managed policy AmazonEC2ContainerRegistryFullAccess to the role that you used to start your notebook instance. There's no need to restart your notebook instance when you do this, the new permissions will be available immediately."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ALGORITHM_NAME = 'multi-model-xgboost'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%sh -s $ALGORITHM_NAME\n",
+    "\n",
+    "algorithm_name=$1\n",
+    "\n",
+    "account=$(aws sts get-caller-identity --query Account --output text)\n",
+    "\n",
+    "# Get the region defined in the current configuration\n",
+    "region=$(aws configure get region)\n",
+    "\n",
+    "ecr_image=\"${account}.dkr.ecr.${region}.amazonaws.com/${algorithm_name}:latest\"\n",
+    "\n",
+    "# If the repository doesn't exist in ECR, create it.\n",
+    "aws ecr describe-repositories --repository-names \"${algorithm_name}\" > /dev/null 2>&1\n",
+    "\n",
+    "if [ $? -ne 0 ]\n",
+    "then\n",
+    "    aws ecr create-repository --repository-name \"${algorithm_name}\" > /dev/null\n",
+    "fi\n",
+    "\n",
+    "# Get the login command from ECR and execute it directly\n",
+    "$(aws ecr get-login --region ${region} --no-include-email --registry-ids ${account})\n",
+    "\n",
+    "# Build the docker image locally with the image name and then push it to ECR\n",
+    "# with the full name.\n",
+    "\n",
+    "# First clear out any prior version of the cloned repo\n",
+    "rm -rf sagemaker-xgboost-container/\n",
+    "\n",
+    "# Clone the xgboost container repo\n",
+    "git clone --single-branch --branch mme https://github.com/aws/sagemaker-xgboost-container.git\n",
+    "cd sagemaker-xgboost-container/\n",
+    "\n",
+    "# Build the \"base\" container image that encompasses the installation of the\n",
+    "# XGBoost framework and all of the dependencies needed.\n",
+    "docker build -q -t xgboost-container-base:0.90-2-cpu-py3 -f docker/0.90-2/base/Dockerfile.cpu .\n",
+    "\n",
+    "# Create the SageMaker XGBoost Container Python package.\n",
+    "python setup.py bdist_wheel --universal\n",
+    "\n",
+    "# Build the \"final\" container image that encompasses the installation of the\n",
+    "# code that implements the SageMaker multi-model container requirements.\n",
+    "docker build -q -t ${algorithm_name} -f docker/0.90-2/final/Dockerfile.cpu .\n",
+    "\n",
+    "docker tag ${algorithm_name} ${ecr_image}\n",
+    "\n",
+    "docker push ${ecr_image}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate synthetic data for housing models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import json\n",
+    "import datetime\n",
+    "import time\n",
+    "from time import gmtime, strftime\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NUM_HOUSES_PER_LOCATION = 1000\n",
+    "LOCATIONS  = ['NewYork_NY',    'LosAngeles_CA',   'Chicago_IL',    'Houston_TX',   'Dallas_TX',\n",
+    "              'Phoenix_AZ',    'Philadelphia_PA', 'SanAntonio_TX', 'SanDiego_CA',  'SanFrancisco_CA']\n",
+    "PARALLEL_TRAINING_JOBS = 4 # len(LOCATIONS) if your account limits can handle it\n",
+    "MAX_YEAR = 2019"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def gen_price(house):\n",
+    "    _base_price = int(house['SQUARE_FEET'] * 150)\n",
+    "    _price = int(_base_price + (10000 * house['NUM_BEDROOMS']) + \\\n",
+    "                               (15000 * house['NUM_BATHROOMS']) + \\\n",
+    "                               (15000 * house['LOT_ACRES']) + \\\n",
+    "                               (15000 * house['GARAGE_SPACES']) - \\\n",
+    "                               (5000 * (MAX_YEAR - house['YEAR_BUILT'])))\n",
+    "    return _price"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def gen_random_house():\n",
+    "    _house = {'SQUARE_FEET':   int(np.random.normal(3000, 750)),\n",
+    "              'NUM_BEDROOMS':  np.random.randint(2, 7),\n",
+    "              'NUM_BATHROOMS': np.random.randint(2, 7) / 2,\n",
+    "              'LOT_ACRES':     round(np.random.normal(1.0, 0.25), 2),\n",
+    "              'GARAGE_SPACES': np.random.randint(0, 4),\n",
+    "              'YEAR_BUILT':    min(MAX_YEAR, int(np.random.normal(1995, 10)))}\n",
+    "    _price = gen_price(_house)\n",
+    "    return [_price, _house['YEAR_BUILT'],   _house['SQUARE_FEET'], \n",
+    "                    _house['NUM_BEDROOMS'], _house['NUM_BATHROOMS'], \n",
+    "                    _house['LOT_ACRES'],    _house['GARAGE_SPACES']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def gen_houses(num_houses):\n",
+    "    _house_list = []\n",
+    "    for i in range(num_houses):\n",
+    "        _house_list.append(gen_random_house())\n",
+    "    _df = pd.DataFrame(_house_list, \n",
+    "                       columns=['PRICE',        'YEAR_BUILT',    'SQUARE_FEET',  'NUM_BEDROOMS',\n",
+    "                                'NUM_BATHROOMS','LOT_ACRES',     'GARAGE_SPACES'])\n",
+    "    return _df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train multiple house value prediction models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sagemaker\n",
+    "from sagemaker import get_execution_role\n",
+    "from sagemaker.predictor import csv_serializer\n",
+    "import boto3\n",
+    "\n",
+    "sm_client = boto3.client(service_name='sagemaker')\n",
+    "runtime_sm_client = boto3.client(service_name='sagemaker-runtime')\n",
+    "\n",
+    "s3 = boto3.resource('s3')\n",
+    "s3_client = boto3.client('s3')\n",
+    "\n",
+    "sagemaker_session = sagemaker.Session()\n",
+    "role = get_execution_role()\n",
+    "\n",
+    "ACCOUNT_ID = boto3.client('sts').get_caller_identity()['Account']\n",
+    "REGION     = boto3.Session().region_name\n",
+    "BUCKET     = sagemaker_session.default_bucket()\n",
+    "\n",
+    "MULTI_MODEL_XGBOOST_IMAGE = '{}.dkr.ecr.{}.amazonaws.com/{}:latest'.format(ACCOUNT_ID, REGION, \n",
+    "                                                                           ALGORITHM_NAME)\n",
+    "\n",
+    "DATA_PREFIX            = 'DEMO_MME_XGBOOST'\n",
+    "HOUSING_MODEL_NAME     = 'housing'\n",
+    "MULTI_MODEL_ARTIFACTS  = 'multi_model_artifacts'\n",
+    "\n",
+    "TRAIN_INSTANCE_TYPE    = 'ml.m4.xlarge'\n",
+    "ENDPOINT_INSTANCE_TYPE = 'ml.m4.xlarge'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Split a given dataset into train, validation, and test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.model_selection import train_test_split\n",
+    "SEED = 7\n",
+    "SPLIT_RATIOS = [0.6, 0.3, 0.1]\n",
+    "\n",
+    "def split_data(df):\n",
+    "    # split data into train and test sets\n",
+    "    seed      = SEED\n",
+    "    val_size  = SPLIT_RATIOS[1]\n",
+    "    test_size = SPLIT_RATIOS[2]\n",
+    "    \n",
+    "    num_samples = df.shape[0]\n",
+    "    X1 = df.values[:num_samples, 1:] # keep only the features, skip the target, all rows\n",
+    "    Y1 = df.values[:num_samples, :1] # keep only the target, all rows\n",
+    "\n",
+    "    # Use split ratios to divide up into train/val/test\n",
+    "    X_train, X_val, y_train, y_val = \\\n",
+    "        train_test_split(X1, Y1, test_size=(test_size + val_size), random_state=seed)\n",
+    "    # Of the remaining non-training samples, give proper ratio to validation and to test\n",
+    "    X_test, X_test, y_test, y_test = \\\n",
+    "        train_test_split(X_val, y_val, test_size=(test_size / (test_size + val_size)), \n",
+    "                         random_state=seed)\n",
+    "    # reassemble the datasets with target in first column and features after that\n",
+    "    _train = np.concatenate([y_train, X_train], axis=1)\n",
+    "    _val   = np.concatenate([y_val,   X_val],   axis=1)\n",
+    "    _test  = np.concatenate([y_test,  X_test],  axis=1)\n",
+    "\n",
+    "    return _train, _val, _test"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Launch a single training job for a given housing location\n",
+    "There is nothing specific to multi-model endpoints in terms of the models it will host. They are trained in the same way as all other SageMaker models. Here we are using the XGBoost estimator and not waiting for the job to complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def launch_training_job(location):\n",
+    "    # clear out old versions of the data\n",
+    "    s3_bucket = s3.Bucket(BUCKET)\n",
+    "    full_input_prefix = '{}/model_prep/{}'.format(DATA_PREFIX, location)\n",
+    "    s3_bucket.objects.filter(Prefix=full_input_prefix + '/').delete()\n",
+    "\n",
+    "    # upload the entire set of data for all three channels\n",
+    "    local_folder = 'data/{}'.format(location)\n",
+    "    inputs = sagemaker_session.upload_data(path=local_folder, key_prefix=full_input_prefix)\n",
+    "    print('Training data uploaded: {}'.format(inputs))\n",
+    "    \n",
+    "    _job = 'xgb-{}'.format(location.replace('_', '-'))\n",
+    "    full_output_prefix = '{}/model_artifacts/{}'.format(DATA_PREFIX, location)\n",
+    "    s3_output_path = 's3://{}/{}'.format(BUCKET, full_output_prefix)\n",
+    "\n",
+    "    xgb = sagemaker.estimator.Estimator(MULTI_MODEL_XGBOOST_IMAGE, role, \n",
+    "                                        train_instance_count=1, train_instance_type=TRAIN_INSTANCE_TYPE,\n",
+    "                                        output_path=s3_output_path, base_job_name=_job,\n",
+    "                                        sagemaker_session=sagemaker_session)\n",
+    "    xgb.set_hyperparameters(max_depth=5, eta=0.2, gamma=4, min_child_weight=6, subsample=0.8, silent=0, \n",
+    "                            early_stopping_rounds=5, objective='reg:linear', num_round=25) \n",
+    "    \n",
+    "    DISTRIBUTION_MODE = 'FullyReplicated'\n",
+    "    train_input = sagemaker.s3_input(s3_data=inputs+'/train', \n",
+    "                                     distribution=DISTRIBUTION_MODE, content_type='csv')\n",
+    "    val_input   = sagemaker.s3_input(s3_data=inputs+'/val', \n",
+    "                                     distribution=DISTRIBUTION_MODE, content_type='csv')\n",
+    "    remote_inputs = {'train': train_input, 'validation': val_input}\n",
+    "\n",
+    "    xgb.fit(remote_inputs, wait=False)\n",
+    "    \n",
+    "    return xgb.latest_training_job.name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Kick off a model training job for each housing location"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def save_data_locally(location, train, val, test):\n",
+    "    os.makedirs('data/{}/train'.format(location))\n",
+    "    np.savetxt( 'data/{0}/train/{0}_train.csv'.format(location), train, delimiter=',', fmt='%.2f')\n",
+    "    \n",
+    "    os.makedirs('data/{}/val'.format(location))\n",
+    "    np.savetxt( 'data/{0}/val/{0}_val.csv'.format(location),     val, delimiter=',', fmt='%.2f')\n",
+    "    \n",
+    "    os.makedirs('data/{}/test'.format(location))\n",
+    "    np.savetxt( 'data/{0}/test/{0}_test.csv'.format(location),   test, delimiter=',', fmt='%.2f')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "import os\n",
+    "\n",
+    "training_jobs = []\n",
+    "\n",
+    "shutil.rmtree('data', ignore_errors=True)\n",
+    "\n",
+    "for loc in LOCATIONS[:PARALLEL_TRAINING_JOBS]:\n",
+    "    _houses = gen_houses(NUM_HOUSES_PER_LOCATION)\n",
+    "    _train, _val, _test = split_data(_houses)\n",
+    "    save_data_locally(loc, _train, _val, _test)\n",
+    "    _job = launch_training_job(loc)\n",
+    "    training_jobs.append(_job)\n",
+    "print('{} training jobs launched: {}'.format(len(training_jobs), training_jobs))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Wait for all model training to finish"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def wait_for_training_job_to_complete(job_name):\n",
+    "    print('Waiting for job {} to complete...'.format(job_name))\n",
+    "    resp = sm_client.describe_training_job(TrainingJobName=job_name)\n",
+    "    status = resp['TrainingJobStatus']\n",
+    "    while status=='InProgress':\n",
+    "        time.sleep(60)\n",
+    "        resp = sm_client.describe_training_job(TrainingJobName=job_name)\n",
+    "        status = resp['TrainingJobStatus']\n",
+    "        if status == 'InProgress':\n",
+    "            print('{} job status: {}'.format(job_name, status))\n",
+    "    print('DONE. Status for {} is {}\\n'.format(job_name, status))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# wait for the jobs to finish\n",
+    "for j in training_jobs:\n",
+    "    wait_for_training_job_to_complete(j)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import models into hosting\n",
+    "A big difference for multi-model endpoints is that when creating the Model entity, the container's `ModelDataUrl` is the S3 prefix where the model artifacts that are invokable by the endpoint are located. The rest of the S3 path will be specified when actually invoking the model. Remember to close the location with a trailing slash.\n",
+    "\n",
+    "The `Mode` of container is specified as `MultiModel` to signify that the container will host multiple models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Deploy model artifacts to be found by the endpoint\n",
+    "As described above, the multi-model endpoint is configured to find its model artifacts in a specific location in S3. For each trained model, we make a copy of its model artifacts into that location.\n",
+    "\n",
+    "In our example, we are storing all the models within a single folder. The implementation of multi-model endpoints is flexible enough to permit an arbitrary folder structure. For a set of housing models for example, you could have a top level folder for each region, and the model artifacts would be copied to those regional folders. The target model referenced when invoking such a model would include the folder path. For example, `northeast/Boston_MA.tar.gz`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "def parse_model_artifacts(model_data_url):\n",
+    "    # extract the s3 key from the full url to the model artifacts\n",
+    "    _s3_key = model_data_url.split('s3://{}/'.format(BUCKET))[1]\n",
+    "    # get the part of the key that identifies the model within the model artifacts folder\n",
+    "    _model_name_plus = _s3_key[_s3_key.find('model_artifacts') + len('model_artifacts') + 1:]\n",
+    "    # finally, get the unique model name (e.g., \"NewYork_NY\")\n",
+    "    _model_name = re.findall('^(.*?)/', _model_name_plus)[0]\n",
+    "    return _s3_key, _model_name "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# make a copy of the model artifacts from the original output of the training job to the place in\n",
+    "# s3 where the multi model endpoint will dynamically load individual models\n",
+    "def deploy_artifacts_to_mme(job_name):\n",
+    "    _resp = sm_client.describe_training_job(TrainingJobName=job_name)\n",
+    "    _source_s3_key, _model_name = parse_model_artifacts(_resp['ModelArtifacts']['S3ModelArtifacts'])\n",
+    "    _copy_source = {'Bucket': BUCKET, 'Key': _source_s3_key}\n",
+    "    _key = '{}/{}/{}.tar.gz'.format(DATA_PREFIX, MULTI_MODEL_ARTIFACTS, _model_name)\n",
+    "    \n",
+    "    print('Copying {} model\\n   from: {}\\n     to: {}...'.format(_model_name, _source_s3_key, _key))\n",
+    "    s3_client.copy_object(Bucket=BUCKET, CopySource=_copy_source, Key=_key)\n",
+    "    return _key"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that we are purposely *not* copying the first model. This will be copied later in the notebook to demonstrate how to dynamically add new models to an already running endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First, clear out old versions of the model artifacts from previous runs of this notebook\n",
+    "s3 = boto3.resource('s3')\n",
+    "s3_bucket = s3.Bucket(BUCKET)\n",
+    "full_input_prefix = '{}/multi_model_artifacts'.format(DATA_PREFIX)\n",
+    "print('Removing old model artifacts from {}'.format(full_input_prefix))\n",
+    "s3_bucket.objects.filter(Prefix=full_input_prefix + '/').delete()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# copy every model except the first one\n",
+    "for job in training_jobs[1:]:\n",
+    "    deploy_artifacts_to_mme(job)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create the Amazon SageMaker model entity\n",
+    "Here we use `boto3` to create the model entity. Instead of describing a single model, it will indicate the use of multi-model semantics and will identify the source location of all specific model artifacts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_multi_model_entity(multi_model_name, role):\n",
+    "    # establish the place in S3 from which the endpoint will pull individual models\n",
+    "    _model_url  = 's3://{}/{}/{}/'.format(BUCKET, DATA_PREFIX, MULTI_MODEL_ARTIFACTS)\n",
+    "    _container = {\n",
+    "        'Image':        MULTI_MODEL_XGBOOST_IMAGE,\n",
+    "        'ModelDataUrl': _model_url,\n",
+    "        'Mode':         'MultiModel'\n",
+    "    }\n",
+    "    create_model_response = sm_client.create_model(\n",
+    "        ModelName = multi_model_name,\n",
+    "        ExecutionRoleArn = role,\n",
+    "        Containers = [_container])\n",
+    "    \n",
+    "    return _model_url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_model_name = '{}-{}'.format(HOUSING_MODEL_NAME, strftime('%Y-%m-%d-%H-%M-%S', gmtime()))\n",
+    "model_url = create_multi_model_entity(multi_model_name, role)\n",
+    "print('Multi model name: {}'.format(multi_model_name))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create the multi-model endpoint\n",
+    "There is nothing special about the SageMaker endpoint config for a multi-model endpoint. You need to consider the appropriate instance type and number of instances for the projected prediction workload. The number and size of the individual models will drive memory requirements.\n",
+    "\n",
+    "Once the endpoint config is in place, the endpoint creation is straightforward."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "endpoint_config_name = multi_model_name\n",
+    "print('Endpoint config name: ' + endpoint_config_name)\n",
+    "\n",
+    "create_endpoint_config_response = sm_client.create_endpoint_config(\n",
+    "    EndpointConfigName = endpoint_config_name,\n",
+    "    ProductionVariants=[{\n",
+    "        'InstanceType': ENDPOINT_INSTANCE_TYPE,\n",
+    "        'InitialInstanceCount': 1,\n",
+    "        'InitialVariantWeight': 1,\n",
+    "        'ModelName': multi_model_name,\n",
+    "        'VariantName': 'AllTraffic'}])\n",
+    "\n",
+    "endpoint_name = multi_model_name\n",
+    "print('Endpoint name: ' + endpoint_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_endpoint_response = sm_client.create_endpoint(\n",
+    "    EndpointName=endpoint_name,\n",
+    "    EndpointConfigName=endpoint_config_name)\n",
+    "print('Endpoint Arn: ' + create_endpoint_response['EndpointArn'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Waiting for {} endpoint to be in service...'.format(endpoint_name))\n",
+    "waiter = sm_client.get_waiter('endpoint_in_service')\n",
+    "waiter.wait(EndpointName=endpoint_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercise the multi-model endpoint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Invoke multiple individual models hosted behind a single endpoint\n",
+    "Here we iterate through a set of housing predictions, choosing the specific location-based housing model at random. Notice the cold start price paid for the first invocation of any given model. Subsequent invocations of the same model take advantage of the model already being loaded into memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def predict_one_house_value(features, model_name):\n",
+    "    print('Using model {} to predict price of this house: {}'.format(full_model_name,\n",
+    "                                                                     features))\n",
+    "    body = ','.join(map(str, features)) + '\\n'\n",
+    "    start_time = time.time()\n",
+    "\n",
+    "    response = runtime_sm_client.invoke_endpoint(\n",
+    "                        EndpointName=endpoint_name,\n",
+    "                        ContentType='text/csv',\n",
+    "                        TargetModel=full_model_name,\n",
+    "                        Body=body)\n",
+    "    predicted_value = json.loads(response['Body'].read())[0]\n",
+    "\n",
+    "    duration = time.time() - start_time\n",
+    "    \n",
+    "    print('${:,.2f}, took {:,d} ms\\n'.format(predicted_value, int(duration * 1000)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Here are the models that the endpoint has at its disposal:')\n",
+    "!aws s3 ls --human-readable --summarize $model_url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# iterate through invocations with random inputs against a random model showing results and latency\n",
+    "for i in range(10):\n",
+    "    model_name = LOCATIONS[np.random.randint(1, len(LOCATIONS[:PARALLEL_TRAINING_JOBS]))]\n",
+    "    full_model_name = '{}.tar.gz'.format(model_name)\n",
+    "    predict_one_house_value(gen_random_house()[1:], full_model_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Dynamically deploy another model\n",
+    "Here we demonstrate the power of dynamic loading of new models. We purposely did not copy the first model when deploying models earlier. Now we deploy an additional model and can immediately invoke it through the multi-model endpoint. As with the earlier models, the first invocation to the new model takes longer, as the endpoint takes time to download the model and load it into memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add another model to the endpoint and exercise it\n",
+    "deploy_artifacts_to_mme(training_jobs[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Invoke the newly deployed model\n",
+    "Exercise the newly deployed model without the need for any endpoint update or restart."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Here are the models that the endpoint has at its disposal:')\n",
+    "!aws s3 ls $model_url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_name = LOCATIONS[0]\n",
+    "full_model_name = '{}.tar.gz'.format(model_name)\n",
+    "for i in range(5):\n",
+    "    features = gen_random_house()\n",
+    "    predict_one_house_value(gen_random_house()[1:], full_model_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Updating a model\n",
+    "To update a model, you would follow the same approach as above and add it as a new model. For example, if you have retrained the `NewYork_NY.tar.gz` model and wanted to start invoking it, you would upload the updated model artifacts behind the S3 prefix with a new name such as `NewYork_NY_v2.tar.gz`, and then change the `TargetModel` field to invoke `NewYork_NY_v2.tar.gz` instead of `NewYork_NY.tar.gz`. You do not want to overwrite the model artifacts in Amazon S3, because the old version of the model might still be loaded in the containers or on the storage volume of the instances on the endpoint. Invocations to the new model could then invoke the old version of the model.\n",
+    "\n",
+    "Alternatively, you could stop the endpoint and re-deploy a fresh set of models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Clean up\n",
+    "Here, to be sure we are not billed for endpoints we are no longer using, we clean up."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# shut down the endpoint\n",
+    "sm_client.delete_endpoint(EndpointName=endpoint_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# and the endpoint config\n",
+    "sm_client.delete_endpoint_config(EndpointConfigName=endpoint_config_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# delete model too\n",
+    "sm_client.delete_model(ModelName=multi_model_name)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "conda_python3",
+   "language": "python",
+   "name": "conda_python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add sample notebooks for multi-model endpoints functionality.

1. `advanced_functionality/multi_model_bring_your_own/multi_model_endpoint_bring_your_own.ipynb` shows how to deploy multiple models to a realtime hosted endpoint with your own custom algorithm.
2. `advanced_functionality/multi_model_xgboost_home_value/xgboost_multi_model_endpoint_home_value.ipynb` shows how to deploy multiple models to a realtime hosted endpoint using a multi-model enabled XGBoost container.
3. `advanced_functionality/multi_model_sklearn_home_value/sklearn_multi_model_endpoint_home_value.ipynb` shows how to deploy multiple models to a realtime hosted endpoint using a multi-model enabled SKLearn container.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
