### PR TITLE
Fix data format for 'inference_data' used for sample prediction

### DIFF
--- a/introduction_to_amazon_algorithms/ipinsights_login/ipinsights-tutorial.ipynb
+++ b/introduction_to_amazon_algorithms/ipinsights_login/ipinsights-tutorial.ipynb
@@ -575,7 +575,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inference_data = train_df[:5].values\n",
+    "inference_data = [(data[0], data[1]) for data in train_df[:5].values]\n",
     "predictor.predict(inference_data)"
    ]
   },


### PR DESCRIPTION
Sample training job fails as `inference_data` due to the data having 3 columns instead of 2; the data is a list of (`user_id, ip_address, Timestamp(...))`

This fixes the issue by only using the first two columns for the training, which are `(user_id, ip_address)`