### PR TITLE
Update bank-marketing repository location and attribution.

### DIFF
--- a/autopilot/sagemaker_autopilot_direct_marketing.ipynb
+++ b/autopilot/sagemaker_autopilot_direct_marketing.ipynb
@@ -82,7 +82,9 @@
    "metadata": {},
    "source": [
     "## Downloading the dataset<a name=\"Downloading\"></a>\n",
-    "Download the [direct marketing dataset](https://archive.ics.uci.edu/ml/datasets/bank+marketing) from the University of California, Irvine ML repository."
+    "Download the [direct marketing dataset](!wget -N https://sagemaker-sample-data-us-west-2.s3-us-west-2.amazonaws.com/autopilot/direct_marketing/bank-additional.zip) from the sample data s3 bucket. \n",
+    "\n",
+    "\\[Moro et al., 2014\\] S. Moro, P. Cortez and P. Rita. A Data-Driven Approach to Predict the Success of Bank Telemarketing. Decision Support Systems, Elsevier, 62:22-31, June 2014"
    ]
   },
   {
@@ -91,7 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget -N https://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank-additional.zip\n",
+    "!wget -N https://sagemaker-sample-data-us-west-2.s3-us-west-2.amazonaws.com/autopilot/direct_marketing/bank-additional.zip\n",
     "!unzip -o bank-additional.zip\n",
     "\n",
     "local_data_path = './bank-additional/bank-additional-full.csv'\n"
@@ -123,7 +125,7 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "data = pd.read_csv(local_data_path, sep=';')\n",
+    "data = pd.read_csv(local_data_path)\n",
     "pd.set_option('display.max_columns', 500)     # Make sure we can see all of the columns\n",
     "pd.set_option('display.max_rows', 10)         # Keep the output on one page\n",
     "data"

--- a/introduction_to_applying_machine_learning/xgboost_direct_marketing/xgboost_direct_marketing_sagemaker.ipynb
+++ b/introduction_to_applying_machine_learning/xgboost_direct_marketing/xgboost_direct_marketing_sagemaker.ipynb
@@ -108,7 +108,9 @@
     "---\n",
     "\n",
     "## Data\n",
-    "Let's start by downloading the [direct marketing dataset](https://archive.ics.uci.edu/ml/datasets/bank+marketing) from UCI's ML Repository."
+    "Let's start by downloading the [direct marketing dataset](https://sagemaker-sample-data-us-west-2.s3-us-west-2.amazonaws.com/autopilot/direct_marketing/bank-additional.zip) from the sample data s3 bucket. \n",
+    "\n",
+    "\\[Moro et al., 2014\\] S. Moro, P. Cortez and P. Rita. A Data-Driven Approach to Predict the Success of Bank Telemarketing. Decision Support Systems, Elsevier, 62:22-31, June 2014\n"
    ]
   },
   {
@@ -119,7 +121,7 @@
    },
    "outputs": [],
    "source": [
-    "!wget https://archive.ics.uci.edu/ml/machine-learning-databases/00222/bank-additional.zip\n",
+    "!wget https://sagemaker-sample-data-us-west-2.s3-us-west-2.amazonaws.com/autopilot/direct_marketing/bank-additional.zip\n",
     "!unzip -o bank-additional.zip"
    ]
   },
@@ -138,7 +140,7 @@
    },
    "outputs": [],
    "source": [
-    "data = pd.read_csv('./bank-additional/bank-additional-full.csv', sep=';')\n",
+    "data = pd.read_csv('./bank-additional/bank-additional-full.csv')\n",
     "pd.set_option('display.max_columns', 500)     # Make sure we can see all of the columns\n",
     "pd.set_option('display.max_rows', 20)         # Keep the output on one page\n",
     "data"


### PR DESCRIPTION
*Description of changes:*
The dataset originally used by these notebooks is not comma separated, but rather semi-colon separated. The autopilot feature currently only supports comma separated files, so this change updates the links to a comma separated version of the same dataset.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
