### PR TITLE
Remove leading whitespace in folder path

### DIFF
--- a/sagemaker-debugger/mnist_tensor_analysis/mnist_tensor_analysis.ipynb
+++ b/sagemaker-debugger/mnist_tensor_analysis/mnist_tensor_analysis.ipynb
@@ -188,7 +188,7 @@
    },
    "outputs": [],
    "source": [
-    "folder_name = \" /tmp/{}\".format(path.split(\"/\")[-1])\n",
+    "folder_name = \"/tmp/{}\".format(path.split(\"/\")[-1])\n",
     "os.system(\"aws s3 cp --recursive {} {}\".format(path,folder_name))\n",
     "print('Downloading tensors into folder: ', folder_name)"
    ]


### PR DESCRIPTION
*Issue #, if available:*
- trial takes infinite time to load because of incorrect folder_name being passed to the `create_trial` fn
*Description of changes:*
- removed leading whitespace in the folder_name


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
