### PR TITLE
Removing custom code

### DIFF
--- a/step-functions-data-science-sdk/machine_learning_workflow_abalone/machine_learning_workflow_abalone.ipynb
+++ b/step-functions-data-science-sdk/machine_learning_workflow_abalone/machine_learning_workflow_abalone.ipynb
@@ -195,6 +195,7 @@
     "import stepfunctions\n",
     "import io\n",
     "import random\n",
+    "import os\n",
     "\n",
     "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
     "from stepfunctions import steps\n",
@@ -210,68 +211,14 @@
     "region = boto3.Session().region_name\n",
     "bucket = session.default_bucket()\n",
     "prefix = 'sagemaker/DEMO-xgboost-regression'\n",
-    "bucket_path = 'https://s3-{}.amazonaws.com/{}'.format(region, bucket)"
+    "bucket_path = 's3://{}/{}/'.format(bucket, prefix)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Prepare the dataset\n",
-    "\n",
-    "The following cell defines utility methods to split a dataset into train, validation, and test datasets. It then defines methods to upload them to an Amazon S3 bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def data_split(FILE_DATA, FILE_TRAIN, FILE_VALIDATION, FILE_TEST, PERCENT_TRAIN, PERCENT_VALIDATION, PERCENT_TEST):\n",
-    "    data = [l for l in open(FILE_DATA, 'r')]\n",
-    "    train_file = open(FILE_TRAIN, 'w')\n",
-    "    valid_file = open(FILE_VALIDATION, 'w')\n",
-    "    tests_file = open(FILE_TEST, 'w')\n",
-    "\n",
-    "    num_of_data = len(data)\n",
-    "    num_train = int((PERCENT_TRAIN/100.0)*num_of_data)\n",
-    "    num_valid = int((PERCENT_VALIDATION/100.0)*num_of_data)\n",
-    "    num_tests = int((PERCENT_TEST/100.0)*num_of_data)\n",
-    "\n",
-    "    data_fractions = [num_train, num_valid, num_tests]\n",
-    "    split_data = [[],[],[]]\n",
-    "\n",
-    "    rand_data_ind = 0\n",
-    "\n",
-    "    for split_ind, fraction in enumerate(data_fractions):\n",
-    "        for i in range(fraction):\n",
-    "            rand_data_ind = random.randint(0, len(data)-1)\n",
-    "            split_data[split_ind].append(data[rand_data_ind])\n",
-    "            data.pop(rand_data_ind)\n",
-    "\n",
-    "    for l in split_data[0]:\n",
-    "        train_file.write(l)\n",
-    "\n",
-    "    for l in split_data[1]:\n",
-    "        valid_file.write(l)\n",
-    "\n",
-    "    for l in split_data[2]:\n",
-    "        tests_file.write(l)\n",
-    "\n",
-    "    train_file.close()\n",
-    "    valid_file.close()\n",
-    "    tests_file.close()\n",
-    "\n",
-    "def write_to_s3(fobj, bucket, key):\n",
-    "    return boto3.Session(region_name=region).resource('s3').Bucket(bucket).Object(key).upload_fileobj(fobj)\n",
-    "\n",
-    "def upload_to_s3(bucket, channel, filename):\n",
-    "    fobj=open(filename, 'rb')\n",
-    "    key = prefix+'/'+channel\n",
-    "    url = 's3://{}/{}/{}'.format(bucket, key, filename)\n",
-    "    print('Writing to {}'.format(url))\n",
-    "    write_to_s3(fobj, bucket, key)"
+    "### Prepare the dataset"
    ]
   },
   {
@@ -291,28 +238,63 @@
     "    from urllib.request import urlretrieve\n",
     "except: #python2\n",
     "    from urllib import urlretrieve\n",
-    "    \n",
+    "\n",
     "# Load the dataset\n",
     "FILE_DATA = 'abalone'\n",
-    "urlretrieve(\"https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/regression/abalone\", FILE_DATA)\n",
+    "urlretrieve(\"https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/regression/abalone\", FILE_DATA)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from sklearn.datasets import load_svmlight_file, dump_svmlight_file\n",
     "\n",
-    "#split the downloaded data into train/test/validation files\n",
+    "data = load_svmlight_file(FILE_DATA)\n",
+    "\n",
+    "# Split the downloaded data into train/test/validation files\n",
+    "PERCENT_TRAIN = 70\n",
+    "PERCENT_VALIDATION = 15\n",
+    "train_data_x, validation_data_x, test_data_x = np.split(data[0].toarray(), \n",
+    "    [int(PERCENT_TRAIN * len(data)), int((PERCENT_TRAIN+PERCENT_VALIDATION)*len(data))])\n",
+    "train_data_y, validation_data_y, test_data_y = np.split(data[1], \n",
+    "    [int(PERCENT_TRAIN * len(data)), int((PERCENT_TRAIN+PERCENT_VALIDATION)*len(data))])\n",
+    "\n",
+    "# Save the files\n",
     "FILE_TRAIN = 'abalone.train'\n",
     "FILE_VALIDATION = 'abalone.validation'\n",
     "FILE_TEST = 'abalone.test'\n",
-    "PERCENT_TRAIN = 70\n",
-    "PERCENT_VALIDATION = 15\n",
-    "PERCENT_TEST = 15\n",
-    "data_split(FILE_DATA, FILE_TRAIN, FILE_VALIDATION, FILE_TEST, PERCENT_TRAIN, PERCENT_VALIDATION, PERCENT_TEST)\n",
     "\n",
-    "#upload the files to the S3 bucket\n",
-    "upload_to_s3(bucket, 'train', FILE_TRAIN)\n",
-    "upload_to_s3(bucket, 'validation', FILE_VALIDATION)\n",
-    "upload_to_s3(bucket, 'test', FILE_TEST)\n",
+    "dump_svmlight_file(train_data_x, train_data_y, FILE_TRAIN)\n",
+    "dump_svmlight_file(validation_data_x, validation_data_y, FILE_VALIDATION)\n",
+    "dump_svmlight_file(test_data_x, test_data_y, FILE_TEST)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# S3 paths\n",
+    "train_s3_path = os.path.join(bucket_path, 'train')\n",
+    "validation_s3_path = os.path.join(bucket_path, 'validation')\n",
+    "test_s3_path = os.path.join(bucket_path, 'test')\n",
+    "output_s3_path = os.path.join(bucket_path, 'output')\n",
     "\n",
-    "train_s3_file = bucket_path + \"/\" + prefix + '/train'\n",
-    "validation_s3_file = bucket_path + \"/\" + prefix + '/validation'\n",
-    "test_s3_file = bucket_path + \"/\" + prefix + '/test'"
+    "# S3 files\n",
+    "train_s3_file = os.path.join(train_s3_path, FILE_TRAIN)\n",
+    "validation_s3_file = os.path.join(validation_s3_path, FILE_VALIDATION)\n",
+    "test_s3_file = os.path.join(test_s3_path, FILE_TEST)\n",
+    "\n",
+    "# Upload the three files to Amazon S3\n",
+    "s3_bucket = boto3.Session().resource('s3').Bucket(bucket)\n",
+    "s3_bucket.Object(train_s3_path).upload_file(FILE_TRAIN)\n",
+    "s3_bucket.Object(validation_s3_path).upload_file(FILE_VALIDATION)\n",
+    "s3_bucket.Object(test_s3_path).upload_file(FILE_TEST)"
    ]
   },
   {
@@ -334,7 +316,7 @@
     "    train_instance_count = 1, \n",
     "    train_instance_type = 'ml.m4.4xlarge',\n",
     "    train_volume_size = 5,\n",
-    "    output_path = bucket_path + \"/\" + prefix + \"/single-xgboost\",\n",
+    "    output_path = output_s3_path,\n",
     "    sagemaker_session = session\n",
     ")\n",
     "\n",
@@ -571,8 +553,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from time import strftime, gmtime\n",
+    "timestamp = strftime('%d-%H-%M-%S', gmtime())\n",
+    "\n",
     "workflow = Workflow(\n",
-    "    name='MyTrainTransformDeploy_v1',\n",
+    "    name='{}-{}'.format('MyTrainTransformDeploy_v1', timestamp),\n",
     "    definition=workflow_definition,\n",
     "    role=workflow_execution_role,\n",
     "    execution_input=execution_input\n",
@@ -697,13 +682,6 @@
    "source": [
     "Workflow.list_workflows(html=True)"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---"
-   ]
   }
  ],
  "metadata": {
@@ -722,7 +700,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The notebook uses custom Python code can be easily replaced by standard functions. This improves readability and promotes best practices. 

*Issue #, if available:*

*Description of changes:*
- Remove custom functions to load, split and upload data.
- Use standard functions in skelarn, numpy and boto3 instead.
- Add timestamp to workflow name to allow for repeated executions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
