### PR TITLE
Fix typo in tensorflow_script_mode_training_and_serving

### DIFF
--- a/sagemaker-python-sdk/tensorflow_script_mode_training_and_serving/tensorflow_script_mode_training_and_serving.ipynb
+++ b/sagemaker-python-sdk/tensorflow_script_mode_training_and_serving/tensorflow_script_mode_training_and_serving.ipynb
@@ -288,7 +288,7 @@
    "source": [
     "predictions2 = predictor2.predict(train_data[:50])\n",
     "for i in range(0, 50):\n",
-    "    prediction = predictions['predictions'][i]\n",
+    "    prediction = predictions2['predictions'][i]\n",
     "    label = train_labels[i]\n",
     "    print('prediction is {}, label is {}, matched: {}'.format(prediction, label, prediction == label))"
    ]


### PR DESCRIPTION
*Description of changes:*
Fixes a small typo in tensorflow_script_mode_training_and_serving, where it would use the predictions of tensorflow version 1.* instead of tensorflow 2.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
