### PR TITLE
consume the subnets and security groups generated in the previous cell

### DIFF
--- a/sagemaker-python-sdk/tensorflow_script_mode_horovod/tensorflow_script_mode_horovod.ipynb
+++ b/sagemaker-python-sdk/tensorflow_script_mode_horovod/tensorflow_script_mode_horovod.ipynb
@@ -522,8 +522,8 @@
     "                       framework_version='1.14',\n",
     "                       py_version='py3',\n",
     "                       distributions=distributions,\n",
-    "                       security_group_ids=['sg-0919a36a89a15222f'],\n",
-    "                       subnets=['subnet-0c07198f3eb022ede', 'subnet-055b2819caae2fd1f'],\n",
+    "                       security_group_ids=security_groups,\n",
+    "                       subnets=subnets,\n",
     "                       base_job_name='hvd-mnist-vpc')"
    ]
   },


### PR DESCRIPTION
*Description of changes:* Static subnet/security groups causes automated testing to break.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
