### PR TITLE
default bucket in r_bring_your_own notebook

### DIFF
--- a/advanced_functionality/r_bring_your_own/r_bring_your_own.ipynb
+++ b/advanced_functionality/r_bring_your_own/r_bring_your_own.ipynb
@@ -50,15 +50,15 @@
    },
    "outputs": [],
    "source": [
-    "bucket = '<your_s3_bucket_name_here>'\n",
-    "prefix = 'sagemaker/DEMO-r-byo'\n",
-    " \n",
     "# Define IAM role\n",
     "import boto3\n",
     "import re\n",
+    "import sagemaker\n",
     "from sagemaker import get_execution_role\n",
     "\n",
-    "role = get_execution_role()"
+    "role = get_execution_role()\n",
+    "bucket = sagemaker.Session().default_bucket()\n",
+    "prefix = 'sagemaker/DEMO-r-byo'"
    ]
   },
   {


### PR DESCRIPTION
*Description of changes:* Bucket previously used a placeholder, which prevented automated testing. Bucket is now defaulted using sagemaker-python-sdk's default_bucket() function.

*Testing Done:* Manually uploaded notebook and ran it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
