### PR TITLE
Fix timeout error waiting for metrics

### DIFF
--- a/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/deepracer_rl.ipynb
+++ b/reinforcement_learning/rl_deepracer_robomaker_coach_gazebo/deepracer_rl.ipynb
@@ -867,7 +867,7 @@
     "import json\n",
     "\n",
     "training_metrics_file = \"training_metrics.json\"\n",
-    "training_metrics_path = \"{}/{}\".format(s3_bucket, training_metrics_file)\n",
+    "training_metrics_path = \"{}/{}\".format(s3_prefix, training_metrics_file)\n",
     "wait_for_s3_object(s3_bucket, training_metrics_path, tmp_dir)\n",
     "\n",
     "json_file = \"{}/{}\".format(tmp_dir, training_metrics_file)\n",


### PR DESCRIPTION
This change fixes an error in the notebook. We were using `s3_bucket` to construct the `training_metrics_path` variable, but we should have been using `s3_prefix`. Without this change, this cell times out because it's looking for a file in the wrong path.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
