### PR TITLE
fix: broken link for eia local notebook instance instructions

### DIFF
--- a/sagemaker-python-sdk/tensorflow_serving_using_elastic_inference_with_your_own_model/tensorflow_serving_pretrained_model_elastic_inference.ipynb
+++ b/sagemaker-python-sdk/tensorflow_serving_using_elastic_inference_with_your_own_model/tensorflow_serving_pretrained_model_elastic_inference.ipynb
@@ -139,7 +139,7 @@
    "source": [
     "## Using EI with a SageMaker notebook instance\n",
     "\n",
-    "There is also the ability to utilize an EI accelerator attached to your local SageMaker notebook instance. This can be done by modifying `instance_type` to `local` and `accelerator_type` to `local_sagemaker_notebook`. For more information, please reference: https://github.com/awslabs/amazon-sagemaker-examples/blob/master/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/tensorflow_iris_dnn_classifier_using_estimators_elastic_inference_local.ipynb"
+    "There is also the ability to utilize an EI accelerator attached to your local SageMaker notebook instance. For more information, please reference: https://docs.aws.amazon.com/sagemaker/latest/dg/ei-notebook-instance.html"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*
We have deprecated the sample notebook: https://github.com/awslabs/amazon-sagemaker-examples/blob/master/sagemaker-python-sdk/tensorflow_iris_dnn_classifier_using_estimators/tensorflow_iris_dnn_classifier_using_estimators_elastic_inference_local.ipynb . but the link is referred in the here: sagemaker-python-sdk/tensorflow_serving_using_elastic_inference_with_your_own_model/tensorflow_serving_pretrained_model_elastic_inference.ipynb

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
