### PR TITLE
Move import sagemaker in xgboost_parquet_input_training.ipynb

### DIFF
--- a/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_parquet_input_training.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_parquet_input_training.ipynb
@@ -21,6 +21,7 @@
     "import os\n",
     "import boto3\n",
     "import re\n",
+    "import sagemaker\n",
     "from sagemaker import get_execution_role\n",
     "\n",
     "role = get_execution_role()\n",
@@ -96,7 +97,6 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "import sagemaker\n",
     "sagemaker.Session().upload_data('abalone_train.parquet', \n",
     "                                bucket=bucket, \n",
     "                                key_prefix=prefix+'/'+'train')\n",


### PR DESCRIPTION
*Issue #, if available:*
The first cell results in error "name 'sagemaker' is not defined"

*Description of changes:*
Moving `import sagemaker` because the first cell needs the sagemaker package. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
