### PR TITLE
Turn off debug flag for pytorch examples

### DIFF
--- a/sagemaker-python-sdk/dgl_gcn/pytorch_gcn.ipynb
+++ b/sagemaker-python-sdk/dgl_gcn/pytorch_gcn.ipynb
@@ -88,14 +88,15 @@
     "params['dataset'] = 'cora'\n",
     "task_tags = [{'Key':'ML Task', 'Value':'DGL'}]\n",
     "estimator = PyTorch(entry_point=CODE_PATH,\n",
-    "                        role=role, \n",
-    "                        train_instance_count=1, \n",
-    "                        train_instance_type='ml.p3.2xlarge', # 'ml.c4.2xlarge '\n",
-    "                        framework_version=\"1.3.1\",\n",
-    "                        py_version='py3',\n",
-    "                        tags=task_tags,\n",
-    "                        hyperparameters=params,\n",
-    "                        sagemaker_session=sess)"
+    "                    role=role,\n",
+    "                    train_instance_count=1,\n",
+    "                    train_instance_type='ml.p3.2xlarge', # 'ml.c4.2xlarge '\n",
+    "                    framework_version=\"1.3.1\",\n",
+    "                    py_version='py3',\n",
+    "                    debugger_hook_config=False,\n",
+    "                    tags=task_tags,\n",
+    "                    hyperparameters=params,\n",
+    "                    sagemaker_session=sess)"
    ]
   },
   {

--- a/sagemaker-python-sdk/dgl_gcn/pytorch_gcn_hypertune.ipynb
+++ b/sagemaker-python-sdk/dgl_gcn/pytorch_gcn_hypertune.ipynb
@@ -130,6 +130,7 @@
     "                    train_instance_type='ml.p3.2xlarge',\n",
     "                    framework_version=\"1.3.1\",\n",
     "                    py_version='py3',\n",
+    "                    debugger_hook_config=False,\n",
     "                    hyperparameters=params,\n",
     "                    sagemaker_session=sess)"
    ]

--- a/sagemaker-python-sdk/dgl_kge/kge_pytorch.ipynb
+++ b/sagemaker-python-sdk/dgl_kge/kge_pytorch.ipynb
@@ -91,6 +91,7 @@
     "                    train_instance_type='ml.p3.2xlarge',\n",
     "                    framework_version=\"1.3.1\",\n",
     "                    py_version='py3',\n",
+    "                    debugger_hook_config=False,\n",
     "                    tags=task_tags,\n",
     "                    hyperparameters=params,\n",
     "                    sagemaker_session=sess)"

--- a/sagemaker-python-sdk/dgl_kge/kge_pytorch_hypertune.ipynb
+++ b/sagemaker-python-sdk/dgl_kge/kge_pytorch_hypertune.ipynb
@@ -116,6 +116,7 @@
     "                    train_instance_type='ml.p3.2xlarge',\n",
     "                    framework_version=\"1.3.1\",\n",
     "                    py_version='py3',\n",
+    "                    debugger_hook_config=False,\n",
     "                    hyperparameters=params,\n",
     "                    sagemaker_session=sess)"
    ]
@@ -240,13 +241,6 @@
     "\n",
     "For more information about Amazon SageMaker's Hyperparameter Tuning, see the AWS documentation."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Turn off the default SageMaker debugger_hook_config.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
