### PR TITLE
Add autopilot customer churn notebook

### DIFF
--- a/autopilot/autopilot_customer_churn.ipynb
+++ b/autopilot/autopilot_customer_churn.ipynb
@@ -241,7 +241,7 @@
     "      'DataSource': {\n",
     "        'S3DataSource': {\n",
     "          'S3DataType': 'S3Prefix',\n",
-    "          'S3Uri': 's3://{bucket}/{prefix}/train'.format(bucket,prefix)\n",
+    "          'S3Uri': 's3://{}/{}/train'.format(bucket,prefix)\n",
     "        }\n",
     "      },\n",
     "      'TargetAttributeName': 'Churn?'\n",
@@ -433,7 +433,7 @@
     "\n",
     "# Load prediction in pandas and compare to ground truth\n",
     "prediction_df = pd.read_csv(StringIO(prediction), header=None)\n",
-    "accuracy = (test_data.reset_index()['Churn?'] == prediction_df[0]).sum() / len(td)\n",
+    "accuracy = (test_data.reset_index()['Churn?'] == prediction_df[0]).sum() / len(test_data_inference)\n",
     "print('Accuracy: {}'.format(accuracy))"
    ]
   },

--- a/autopilot/autopilot_customer_churn.ipynb
+++ b/autopilot/autopilot_customer_churn.ipynb
@@ -1,0 +1,505 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Customer Churn Prediction with Amazon SageMaker Autopilot\n",
+    "_**Using AutoPilot to Predict Mobile Customer Departure**_\n",
+    "\n",
+    "---\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Contents\n",
+    "\n",
+    "1. [Introduction](#Introduction)\n",
+    "1. [Setup](#Setup)\n",
+    "1. [Data](#Data)\n",
+    "1. [Train](#Settingup)\n",
+    "1. [Autopilot Results](#Results)\n",
+    "1. [Host](#Host)\n",
+    "1. [Cleanup](#Cleanup)\n",
+    "\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "Amazon SageMaker Autopilot is an automated machine learning (commonly referred to as AutoML) solution for tabular datasets. You can use SageMaker Autopilot in different ways: on autopilot (hence the name) or with human guidance, without code through SageMaker Studio, or using the AWS SDKs. This notebook, as a first glimpse, will use the AWS SDKs to simply create and deploy a machine learning model.\n",
+    "\n",
+    "Losing customers is costly for any business.  Identifying unhappy customers early on gives you a chance to offer them incentives to stay.  This notebook describes using machine learning (ML) for the automated identification of unhappy customers, also known as customer churn prediction. ML models rarely give perfect predictions though, so this notebook is also about how to incorporate the relative costs of prediction mistakes when determining the financial outcome of using ML.\n",
+    "\n",
+    "We use an example of churn that is familiar to all of us–leaving a mobile phone operator.  Seems like I can always find fault with my provider du jour! And if my provider knows that I’m thinking of leaving, it can offer timely incentives–I can always use a phone upgrade or perhaps have a new feature activated–and I might just stick around. Incentives are often much more cost effective than losing and reacquiring a customer.\n",
+    "\n",
+    "---\n",
+    "## Setup\n",
+    "\n",
+    "_This notebook was created and tested on an ml.m4.xlarge notebook instance._\n",
+    "\n",
+    "Let's start by specifying:\n",
+    "\n",
+    "- The S3 bucket and prefix that you want to use for training and model data.  This should be within the same region as the Notebook Instance, training, and hosting.\n",
+    "- The IAM role arn used to give training and hosting access to your data. See the documentation for how to create these.  Note, if more than one role is required for notebook instances, training, and/or hosting, please replace the boto regexp with a the appropriate full IAM role arn string(s)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "isConfigCell": true,
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import sagemaker\n",
+    "import boto3\n",
+    "from sagemaker import get_execution_role\n",
+    "\n",
+    "region = boto3.Session().region_name\n",
+    "\n",
+    "session = sagemaker.Session()\n",
+    "\n",
+    "# You can modify the following to use a bucket of your choosing\n",
+    "bucket = session.default_bucket()\n",
+    "prefix = 'sagemaker/DEMO-autopilot-churn'\n",
+    "\n",
+    "role = get_execution_role()\n",
+    "\n",
+    "# This is the client we will use to interact with SageMaker AutoPilot\n",
+    "sm = boto3.Session().client(service_name='sagemaker',region_name=region)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we'll import the Python libraries we'll need for the remainder of the exercise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import io\n",
+    "import os\n",
+    "import sys\n",
+    "import time\n",
+    "import json\n",
+    "from IPython.display import display\n",
+    "from time import strftime, gmtime\n",
+    "import sagemaker\n",
+    "from sagemaker.predictor import csv_serializer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Data\n",
+    "\n",
+    "Mobile operators have historical records on which customers ultimately ended up churning and which continued using the service. We can use this historical information to construct an ML model of one mobile operator’s churn using a process called training. After training the model, we can pass the profile information of an arbitrary customer (the same profile information that we used to train the model) to the model, and have the model predict whether this customer is going to churn. Of course, we expect the model to make mistakes–after all, predicting the future is tricky business! But I’ll also show how to deal with prediction errors.\n",
+    "\n",
+    "The dataset we use is publicly available and was mentioned in the book [Discovering Knowledge in Data](https://www.amazon.com/dp/0470908742/) by Daniel T. Larose. It is attributed by the author to the University of California Irvine Repository of Machine Learning Datasets.  Let's download and read that dataset in now:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wget http://dataminingconsultant.com/DKD2e_data_sets.zip\n",
+    "!unzip -o DKD2e_data_sets.zip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Upload the dataset to S3\n",
+    "\n",
+    "Before you run Autopilot on the dataset, first perform a check of the dataset to make sure that it has no obvious errors. The Autopilot process can take long time, and it's generally a good practice to inspect the dataset before you start a job. This particular dataset is small, so you can inspect it in the notebook instance itself. If you have a larger dataset that will not fit in a notebook instance memory, inspect the dataset offline using a big data analytics tool like Apache Spark. [Deequ](https://github.com/awslabs/deequ) is a library built on top of Apache Spark that can be helpful for performing checks on large datasets. Autopilot is capable of handling datasets up to 5 GB.\n",
+    "\n",
+    "Read the data into a Pandas data frame and take a look."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "churn = pd.read_csv('./Data sets/churn.txt')\n",
+    "pd.set_option('display.max_columns', 500)\n",
+    "churn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By modern standards, it’s a relatively small dataset, with only 3,333 records, where each record uses 21 attributes to describe the profile of a customer of an unknown US mobile operator. The attributes are:\n",
+    "\n",
+    "- `State`: the US state in which the customer resides, indicated by a two-letter abbreviation; for example, OH or NJ\n",
+    "- `Account Length`: the number of days that this account has been active\n",
+    "- `Area Code`: the three-digit area code of the corresponding customer’s phone number\n",
+    "- `Phone`: the remaining seven-digit phone number\n",
+    "- `Int’l Plan`: whether the customer has an international calling plan: yes/no\n",
+    "- `VMail Plan`: whether the customer has a voice mail feature: yes/no\n",
+    "- `VMail Message`: presumably the average number of voice mail messages per month\n",
+    "- `Day Mins`: the total number of calling minutes used during the day\n",
+    "- `Day Calls`: the total number of calls placed during the day\n",
+    "- `Day Charge`: the billed cost of daytime calls\n",
+    "- `Eve Mins, Eve Calls, Eve Charge`: the billed cost for calls placed during the evening\n",
+    "- `Night Mins`, `Night Calls`, `Night Charge`: the billed cost for calls placed during nighttime\n",
+    "- `Intl Mins`, `Intl Calls`, `Intl Charge`: the billed cost for international calls\n",
+    "- `CustServ Calls`: the number of calls placed to Customer Service\n",
+    "- `Churn?`: whether the customer left the service: true/false\n",
+    "\n",
+    "The last attribute, `Churn?`, is known as the target attribute–the attribute that we want the ML model to predict.  Because the target attribute is binary, our model will be performing binary prediction, also known as binary classification."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reserve some data for calling inference on the model\n",
+    "\n",
+    "Divide the data into training and testing splits. The training split is used by SageMaker Autopilot. The testing split is reserved to perform inference using the suggested model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_data = churn.sample(frac=0.8,random_state=200)\n",
+    "\n",
+    "test_data = churn.drop(train_data.index)\n",
+    "\n",
+    "test_data_no_target = test_data.drop(columns=['Churn?'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we'll upload these files to S3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_file = 'train_data.csv';\n",
+    "train_data.to_csv(train_file, index=False, header=True)\n",
+    "train_data_s3_path = session.upload_data(path=train_file, key_prefix=prefix + \"/train\")\n",
+    "print('Train data uploaded to: ' + train_data_s3_path)\n",
+    "\n",
+    "test_file = 'test_data.csv';\n",
+    "test_data_no_target.to_csv(test_file, index=False, header=False)\n",
+    "test_data_s3_path = session.upload_data(path=test_file, key_prefix=prefix + \"/test\")\n",
+    "print('Test data uploaded to: ' + test_data_s3_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Setting up the SageMaker Autopilot Job<a name=\"Settingup\"></a>\n",
+    "\n",
+    "After uploading the dataset to Amazon S3, you can invoke Autopilot to find the best ML pipeline to train a model on this dataset. \n",
+    "\n",
+    "The required inputs for invoking a Autopilot job are:\n",
+    "* Amazon S3 location for input dataset and for all output artifacts\n",
+    "* Name of the column of the dataset you want to predict (`Churn?` in this case) \n",
+    "* An IAM role\n",
+    "\n",
+    "Currently Autopilot supports only tabular datasets in CSV format. Either all files should have a header row, or the first file of the dataset, when sorted in alphabetical/lexical order by name, is expected to have a header row."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_data_config = [{\n",
+    "      'DataSource': {\n",
+    "        'S3DataSource': {\n",
+    "          'S3DataType': 'S3Prefix',\n",
+    "          'S3Uri': 's3://{bucket}/{prefix}/train'.format(bucket,prefix)\n",
+    "        }\n",
+    "      },\n",
+    "      'TargetAttributeName': 'Churn?'\n",
+    "    }\n",
+    "  ]\n",
+    "\n",
+    "output_data_config = {\n",
+    "    'S3OutputPath': 's3://{}/{}/output'.format(bucket,prefix)\n",
+    "  }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also specify the type of problem you want to solve with your dataset (`Regression, MulticlassClassification, BinaryClassification`). In case you are not sure, SageMaker Autopilot will infer the problem type based on statistics of the target column (the column you want to predict). \n",
+    "\n",
+    "You have the option to limit the running time of a SageMaker Autopilot job by providing either the maximum number of pipeline evaluations or candidates (one pipeline evaluation is called a `Candidate` because it generates a candidate model) or providing the total time allocated for the overall Autopilot job. Under default settings, this job takes about four hours to run. This varies between runs because of the nature of the exploratory process Autopilot uses to find optimal training parameters."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Launching the SageMaker Autopilot Job<a name=\"Launching\"></a>\n",
+    "\n",
+    "You can now launch the Autopilot job by calling the `create_auto_ml_job` API. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from time import gmtime, strftime, sleep\n",
+    "timestamp_suffix = strftime('%d-%H-%M-%S', gmtime())\n",
+    "\n",
+    "auto_ml_job_name = 'automl-churn-' + timestamp_suffix\n",
+    "print('AutoMLJobName: ' + auto_ml_job_name)\n",
+    "\n",
+    "sm.create_auto_ml_job(AutoMLJobName=auto_ml_job_name,\n",
+    "                      InputDataConfig=input_data_config,\n",
+    "                      OutputDataConfig=output_data_config,\n",
+    "                      RoleArn=role)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Tracking SageMaker Autopilot job progress<a name=\"Tracking\"></a>\n",
+    "SageMaker Autopilot job consists of the following high-level steps : \n",
+    "* Analyzing Data, where the dataset is analyzed and Autopilot comes up with a list of ML pipelines that should be tried out on the dataset. The dataset is also split into train and validation sets.\n",
+    "* Feature Engineering, where Autopilot performs feature transformation on individual features of the dataset as well as at an aggregate level.\n",
+    "* Model Tuning, where the top performing pipeline is selected along with the optimal hyperparameters for the training algorithm (the last stage of the pipeline). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print ('JobStatus - Secondary Status')\n",
+    "print('------------------------------')\n",
+    "\n",
+    "\n",
+    "describe_response = sm.describe_auto_ml_job(AutoMLJobName=auto_ml_job_name)\n",
+    "print (describe_response['AutoMLJobStatus'] + \" - \" + describe_response['AutoMLJobSecondaryStatus'])\n",
+    "job_run_status = describe_response['AutoMLJobStatus']\n",
+    "    \n",
+    "while job_run_status not in ('Failed', 'Completed', 'Stopped'):\n",
+    "    describe_response = sm.describe_auto_ml_job(AutoMLJobName=auto_ml_job_name)\n",
+    "    job_run_status = describe_response['AutoMLJobStatus']\n",
+    "    \n",
+    "    print (describe_response['AutoMLJobStatus'] + \" - \" + describe_response['AutoMLJobSecondaryStatus'])\n",
+    "    sleep(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "toc-hr-collapsed": true
+   },
+   "source": [
+    "---\n",
+    "## Results\n",
+    "\n",
+    "Now use the describe_auto_ml_job API to look up the best candidate selected by the SageMaker Autopilot job. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "best_candidate = sm.describe_auto_ml_job(AutoMLJobName=auto_ml_job_name)['BestCandidate']\n",
+    "best_candidate_name = best_candidate['CandidateName']\n",
+    "print(best_candidate)\n",
+    "print('\\n')\n",
+    "print(\"CandidateName: \" + best_candidate_name)\n",
+    "print(\"FinalAutoMLJobObjectiveMetricName: \" + best_candidate['FinalAutoMLJobObjectiveMetric']['MetricName'])\n",
+    "print(\"FinalAutoMLJobObjectiveMetricValue: \" + str(best_candidate['FinalAutoMLJobObjectiveMetric']['Value']))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Due to some randomness in the algorithms involved, different runs will provide slightly different results, but accuracy will be around or above $96\\%$, which is a good result."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Host\n",
+    "\n",
+    "Now that we've trained the algorithm, let's create a model and deploy it to a hosted endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "timestamp_suffix = strftime('%d-%H-%M-%S', gmtime())\n",
+    "model_name = best_candidate_name + timestamp_suffix + \"-model\"\n",
+    "model_arn = sm.create_model(Containers=best_candidate['InferenceContainers'],\n",
+    "                            ModelName=model_name,\n",
+    "                            ExecutionRoleArn=role)\n",
+    "\n",
+    "epc_name = best_candidate_name + timestamp_suffix + \"-epc\"\n",
+    "ep_config = sm.create_endpoint_config(EndpointConfigName = epc_name,\n",
+    "                                      ProductionVariants=[{'InstanceType': 'ml.m5.2xlarge',\n",
+    "                                                           'InitialInstanceCount': 1,\n",
+    "                                                           'ModelName': model_name,\n",
+    "                                                           'VariantName': 'main'}])\n",
+    "\n",
+    "ep_name = best_candidate_name + timestamp_suffix + \"-ep\"\n",
+    "create_endpoint_response = sm.create_endpoint(EndpointName=ep_name,\n",
+    "                                              EndpointConfigName=epc_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sm.get_waiter('endpoint_in_service').wait(EndpointName=ep_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Evaluate\n",
+    "\n",
+    "Now that we have a hosted endpoint running, we can make real-time predictions from our model very easily, simply by making an http POST request.  But first, we'll need to setup serializers and deserializers for passing our `test_data` NumPy arrays to the model behind the endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from io import StringIO\n",
+    "from sagemaker.predictor import RealTimePredictor\n",
+    "from sagemaker.content_types import CONTENT_TYPE_CSV\n",
+    "\n",
+    "\n",
+    "predictor = RealTimePredictor(\n",
+    "    endpoint=ep_name,\n",
+    "    sagemaker_session=session,\n",
+    "    content_type=CONTENT_TYPE_CSV,\n",
+    "    accept=CONTENT_TYPE_CSV)\n",
+    "\n",
+    "# Remove the target column from the test data\n",
+    "test_data_inference = test_data.drop('Churn?', axis=1)\n",
+    "\n",
+    "# Obtain predictions from SageMaker endpoint\n",
+    "prediction = predictor.predict(test_data_inference.to_csv(sep=',', header=False, index=False)).decode('utf-8')\n",
+    "\n",
+    "# Load prediction in pandas and compare to ground truth\n",
+    "prediction_df = pd.read_csv(StringIO(prediction), header=None)\n",
+    "accuracy = (test_data.reset_index()['Churn?'] == prediction_df[0]).sum() / len(td)\n",
+    "print('Accuracy: {}'.format(accuracy))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Cleanup\n",
+    "\n",
+    "The Autopilot job creates many underlying artifacts such as dataset splits, preprocessing scripts, or preprocessed data, etc. This code, when un-commented, deletes them. This operation deletes all the generated models and the auto-generated notebooks as well. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3 = boto3.resource('s3')\n",
+    "s3_bucket = s3.Bucket(bucket)\n",
+    "\n",
+    "job_outputs_prefix = '{}/output/{}'.format(prefix, auto_ml_job_name)\n",
+    "s3_bucket.objects.filter(Prefix=job_outputs_prefix).delete()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we delete the endpoint and associated resources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sm.delete_endpoint(EndpointName=ep_name)\n",
+    "sm.delete_endpoint_config(EndpointConfigName=epc_name)\n",
+    "sm.delete_model(ModelName=model_name)"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "conda_python3",
+   "language": "python",
+   "name": "conda_python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  },
+  "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/autopilot/autopilot_customer_churn.ipynb
+++ b/autopilot/autopilot_customer_churn.ipynb
@@ -165,7 +165,7 @@
     "- `CustServ Calls`: the number of calls placed to Customer Service\n",
     "- `Churn?`: whether the customer left the service: true/false\n",
     "\n",
-    "The last attribute, `Churn?`, is known as the target attribute–the attribute that we want the ML model to predict.  Because the target attribute is binary, our model will be performing binary prediction, also known as binary classification."
+    "The last attribute, `Churn?`, is known as the target attribute–the attribute that we want the ML model to predict."
    ]
   },
   {
@@ -259,6 +259,8 @@
    "source": [
     "You can also specify the type of problem you want to solve with your dataset (`Regression, MulticlassClassification, BinaryClassification`). In case you are not sure, SageMaker Autopilot will infer the problem type based on statistics of the target column (the column you want to predict). \n",
     "\n",
+    "Because the target attribute, ```Churn?```, is binary, our model will be performing binary prediction, also known as binary classification. In this example we will let AutoPilot infer the type of problem for us.\n",
+    "\n",
     "You have the option to limit the running time of a SageMaker Autopilot job by providing either the maximum number of pipeline evaluations or candidates (one pipeline evaluation is called a `Candidate` because it generates a candidate model) or providing the total time allocated for the overall Autopilot job. Under default settings, this job takes about four hours to run. This varies between runs because of the nature of the exploratory process Autopilot uses to find optimal training parameters."
    ]
   },
@@ -268,7 +270,7 @@
    "source": [
     "### Launching the SageMaker Autopilot Job<a name=\"Launching\"></a>\n",
     "\n",
-    "You can now launch the Autopilot job by calling the `create_auto_ml_job` API. "
+    "You can now launch the Autopilot job by calling the `create_auto_ml_job` API. We limit the number of candidates to 20 so that the job finishes in a few minutes."
    ]
   },
   {
@@ -286,6 +288,9 @@
     "sm.create_auto_ml_job(AutoMLJobName=auto_ml_job_name,\n",
     "                      InputDataConfig=input_data_config,\n",
     "                      OutputDataConfig=output_data_config,\n",
+    "                      AutoMLJobConfig={'CompletionCriteria':\n",
+    "                                       {'MaxCandidates': 20}\n",
+    "                                      },\n",
     "                      RoleArn=role)"
    ]
   },
@@ -353,7 +358,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Due to some randomness in the algorithms involved, different runs will provide slightly different results, but accuracy will be around or above $96\\%$, which is a good result."
+    "Due to some randomness in the algorithms involved, different runs will provide slightly different results, but accuracy will be around or above $93\\%$, which is a good result."
    ]
   },
   {
@@ -453,11 +458,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s3 = boto3.resource('s3')\n",
-    "s3_bucket = s3.Bucket(bucket)\n",
+    "#s3 = boto3.resource('s3')\n",
+    "#s3_bucket = s3.Bucket(bucket)\n",
     "\n",
-    "job_outputs_prefix = '{}/output/{}'.format(prefix, auto_ml_job_name)\n",
-    "s3_bucket.objects.filter(Prefix=job_outputs_prefix).delete()"
+    "#job_outputs_prefix = '{}/output/{}'.format(prefix, auto_ml_job_name)\n",
+    "#s3_bucket.objects.filter(Prefix=job_outputs_prefix).delete()"
    ]
   },
   {


### PR DESCRIPTION
Similar to the XGBoost customer churn notebook, but using autopilot
instead.

*Issue #, if available:*

*Description of changes:*

To support Aurora ML blog (https://aws.amazon.com/blogs/aws/new-for-amazon-aurora-use-machine-learning-directly-from-your-databases/) it is necessary to have a Customer Churn Autopilot example. 

The blog currently references: https://github.com/awslabs/amazon-sagemaker-examples/blob/master/introduction_to_applying_machine_learning/xgboost_customer_churn/xgboost_customer_churn.ipynb but the resulting endpoint from this notebook is not usable from Aurora, since it does not include all the pre/post processing code generated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
