### PR TITLE
Bug Fix: Updated kernel from python3 to conda_python3 so that it can be import…

### DIFF
--- a/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
@@ -546,9 +546,9 @@
   "anaconda-cloud": {},
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "conda_python3",
    "language": "python",
-   "name": "python3"
+   "name": "conda_python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
…ed to SageMaker notebooks

*Issue #, if available:*

*Description of changes:*
Update the kernel to the correct version, from python3 to conda_python3. So that it can be imported with correct kernel into SageMaker.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
