### PR TITLE
updating object_detection_image_json_format.ipynb

### DIFF
--- a/introduction_to_amazon_algorithms/object_detection_pascalvoc_coco/object_detection_image_json_format.ipynb
+++ b/introduction_to_amazon_algorithms/object_detection_pascalvoc_coco/object_detection_image_json_format.ipynb
@@ -544,7 +544,7 @@
    },
    "outputs": [],
    "source": [
-    "!wget -O test.jpg https://images.pexels.com/photos/980382/pexels-photo-980382.jpeg\n",
+    "!curl --output test.jpg https://images.pexels.com/photos/980382/pexels-photo-980382.jpeg\n",
     "file_name = 'test.jpg'\n",
     "\n",
     "with open(file_name, 'rb') as image:\n",


### PR DESCRIPTION
*Issue #, if available:*
while following the notebook of object_detection_image_json_format.ipynb, when trying to download the image, the below error is received

--2020-03-24 18:49:54--  https://images.pexels.com/photos/980382/pexels-photo-980382.jpeg
Resolving images.pexels.com (images.pexels.com)... 104.17.209.102, 104.17.208.102, 2606:4700::6811:d166, ...
Connecting to images.pexels.com (images.pexels.com)|104.17.209.102|:443... connected.
HTTP request sent, awaiting response... 503 Service Temporarily Unavailable
2020-03-24 18:49:55 ERROR 503: Service Temporarily Unavailable.

*Description of changes:*
In order to fix the above issue, the below line 
!wget -O test.jpg https://images.pexels.com/photos/980382/pexels-photo-980382.jpeg

is changed to 
!curl --output test.jpg https://images.pexels.com/photos/980382/pexels-photo-980382.jpeg

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
