### PR TITLE
Tiny issue with predict function

### DIFF
--- a/advanced_functionality/multi_model_sklearn_home_value/sklearn_multi_model_endpoint_home_value.ipynb
+++ b/advanced_functionality/multi_model_sklearn_home_value/sklearn_multi_model_endpoint_home_value.ipynb
@@ -783,7 +783,7 @@
    "outputs": [],
    "source": [
     "def predict_one_house_value(features, model_name):\n",
-    "    print('Using model {} to predict price of this house: {}'.format(full_model_name,\n",
+    "    print('Using model {} to predict price of this house: {}'.format(model_name,\n",
     "                                                                     features))\n",
     "\n",
     "    _float_features = [float(i) for i in features]\n",


### PR DESCRIPTION
The statement prints `full_model_name` when it should be printing `model_name`

*Issue #, if available:*

*Description of changes:*

The print statement within the file `sklearn_multi_model_endpoint_home_value.ipynb`'s `predict_one_house_value` function prints `full_model_name` instead of `model_name` like it should

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
