### PR TITLE
Fixed variable name in sklearn_multi_model_endpoint_home_value.ipynb 

### DIFF
--- a/advanced_functionality/multi_model_sklearn_home_value/sklearn_multi_model_endpoint_home_value.ipynb
+++ b/advanced_functionality/multi_model_sklearn_home_value/sklearn_multi_model_endpoint_home_value.ipynb
@@ -783,7 +783,7 @@
    "outputs": [],
    "source": [
     "def predict_one_house_value(features, model_name):\n",
-    "    print('Using model {} to predict price of this house: {}'.format(full_model_name,\n",
+    "    print('Using model {} to predict price of this house: {}'.format(model_name,\n",
     "                                                                     features))\n",
     "\n",
     "    _float_features = [float(i) for i in features]\n",
@@ -794,7 +794,7 @@
     "    _response = runtime_sm_client.invoke_endpoint(\n",
     "                        EndpointName=endpoint_name,\n",
     "                        ContentType='text/csv',\n",
-    "                        TargetModel=full_model_name,\n",
+    "                        TargetModel=model_name,\n",
     "                        Body=_body)\n",
     "    _predicted_value = json.loads(_response['Body'].read())[0]\n",
     "\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixed wrong variable name (`full_model_name`), replaced it with `model_name` in the `predict_one_house_value` function

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
