### PR TITLE
Wait after performing some steps in the Studio Getting Started notebook

### DIFF
--- a/aws_sagemaker_studio/getting_started/xgboost_customer_churn_studio.ipynb
+++ b/aws_sagemaker_studio/getting_started/xgboost_customer_churn_studio.ipynb
@@ -607,9 +607,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from time import sleep\n",
+    "\n",
     "current_endpoint_capture_prefix = '{}/{}'.format(data_capture_prefix, endpoint_name)\n",
+    "for _ in range(12): # wait up to a minute to see captures in S3\n",
+    "    capture_files = S3Downloader.list(\"s3://{}/{}\".format(bucket, current_endpoint_capture_prefix))\n",
+    "    if capture_files:\n",
+    "        break\n",
+    "    sleep(5)\n",
+    "\n",
     "print(\"Found Data Capture Files:\")\n",
-    "capture_files = S3Downloader.list(\"s3://{}/{}\".format(bucket, current_endpoint_capture_prefix))\n",
     "print(capture_files)"
    ]
   },
@@ -840,8 +847,6 @@
    "outputs": [],
    "source": [
     "from threading import Thread\n",
-    "from time import sleep\n",
-    "import time\n",
     "\n",
     "runtime_client = boto3.client('runtime.sagemaker')\n",
     "\n",
@@ -853,7 +858,7 @@
     "            response = runtime_client.invoke_endpoint(EndpointName=ep_name,\n",
     "                                          ContentType='text/csv', \n",
     "                                          Body=payload)\n",
-    "            time.sleep(1)\n",
+    "            sleep(1)\n",
     "            \n",
     "def invoke_endpoint_forever():\n",
     "    while True:\n",
@@ -903,6 +908,15 @@
    "outputs": [],
    "source": [
     "latest_execution = mon_executions[-1]\n",
+    "latest_execution.wait()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "print(\"Latest execution result: {}\".format(latest_execution.describe()['ExitMessage']))\n",
     "report_uri = latest_execution.output.destination\n",
     "\n",
@@ -935,7 +949,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can plug in the processing job arn for a single execution of the monitoring into this notebook to see more detailed visualizations of the violations and distribution statistics of the data captue that was processed in that execution\n"
+    "You can plug in the processing job arn for a single execution of the monitoring into [this notebook](https://github.com/awslabs/amazon-sagemaker-examples/blob/master/sagemaker_model_monitor/visualization/SageMaker-Model-Monitor-Visualize.ipynb) to see more detailed visualizations of the violations and distribution statistics of the data captue that was processed in that execution\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "latest_execution.describe()['ProcessingJobArn']"
    ]
   },
   {
@@ -955,8 +978,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sess.delete_monitoring_schedule(mon_schedule_name)\n",
+    "try:\n",
+    "    sess.delete_monitoring_schedule(mon_schedule_name)\n",
+    "except:\n",
+    "    pass\n",
+    "while True:\n",
+    "    try:\n",
+    "        print(\"Waiting for schedule to be deleted\")\n",
+    "        sess.describe_monitoring_schedule(mon_schedule_name)\n",
+    "        sleep(15)\n",
+    "    except:\n",
+    "        print(\"Schedule deleted\")\n",
+    "        break\n",
+    "\n",
     "sess.delete_endpoint(xgb_predictor.endpoint)\n",
+    "\n",
     "def cleanup(experiment):\n",
     "    '''Clean up everything in the given experiment object'''\n",
     "    for trial_summary in experiment.list_trials():\n",
@@ -975,13 +1011,6 @@
     "\n",
     "cleanup(customer_churn_experiment)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add wait after enabling data capture to give data upload time to take place
* Add wait on monitoring execution to allow it to complete
* Wait after deleting monitoring schedule, before proceeding to endpoint deletion


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
