### PR TITLE
fix: change s3 endpoint domain to .com.cn if region is cn regions

### DIFF
--- a/sagemaker-spark/pyspark_mnist/pyspark_mnist_custom_estimator.ipynb
+++ b/sagemaker-spark/pyspark_mnist/pyspark_mnist_custom_estimator.ipynb
@@ -93,8 +93,10 @@
    "source": [
     "import boto3\n",
     "\n",
+    "cn_regions = ['cn-north-1', 'cn-northwest-1']",
     "region = boto3.Session().region_name\n",
-    "spark._jsc.hadoopConfiguration().set('fs.s3a.endpoint', 's3.{}.amazonaws.com'.format(region))\n",
+    "endpoint_domain = 'com.cn' if region in cn_regions else 'com'",
+    "spark._jsc.hadoopConfiguration().set('fs.s3a.endpoint', 's3.{}.amazonaws.{}'.format(region, endpoint_domain))\n",
     "\n",
     "trainingData = spark.read.format('libsvm')\\\n",
     "    .option('numFeatures', '784')\\\n",

--- a/sagemaker-spark/pyspark_mnist/pyspark_mnist_kmeans.ipynb
+++ b/sagemaker-spark/pyspark_mnist/pyspark_mnist_kmeans.ipynb
@@ -94,8 +94,10 @@
    "source": [
     "import boto3\n",
     "\n",
+    "cn_regions = ['cn-north-1', 'cn-northwest-1']",
     "region = boto3.Session().region_name\n",
-    "spark._jsc.hadoopConfiguration().set('fs.s3a.endpoint', 's3.{}.amazonaws.com'.format(region))\n",
+    "endpoint_domain = 'com.cn' if region in cn_regions else 'com'",
+    "spark._jsc.hadoopConfiguration().set('fs.s3a.endpoint', 's3.{}.amazonaws.{}'.format(region, endpoint_domain))\n",
     "\n",
     "trainingData = spark.read.format('libsvm')\\\n",
     "    .option('numFeatures', '784')\\\n",

--- a/sagemaker-spark/pyspark_mnist/pyspark_mnist_pca_kmeans.ipynb
+++ b/sagemaker-spark/pyspark_mnist/pyspark_mnist_pca_kmeans.ipynb
@@ -93,8 +93,10 @@
    "source": [
     "import boto3\n",
     "\n",
+    "cn_regions = ['cn-north-1', 'cn-northwest-1']",
     "region = boto3.Session().region_name\n",
-    "spark._jsc.hadoopConfiguration().set('fs.s3a.endpoint', 's3.{}.amazonaws.com'.format(region))\n",
+    "endpoint_domain = 'com.cn' if region in cn_regions else 'com'",
+    "spark._jsc.hadoopConfiguration().set('fs.s3a.endpoint', 's3.{}.amazonaws.{}'.format(region, endpoint_domain))\n",
     "\n",
     "trainingData = spark.read.format('libsvm')\\\n",
     "    .option('numFeatures', '784')\\\n",

--- a/sagemaker-spark/pyspark_mnist/pyspark_mnist_pca_mllib_kmeans.ipynb
+++ b/sagemaker-spark/pyspark_mnist/pyspark_mnist_pca_mllib_kmeans.ipynb
@@ -97,8 +97,10 @@
    "source": [
     "import boto3\n",
     "\n",
+    "cn_regions = ['cn-north-1', 'cn-northwest-1']",
     "region = boto3.Session().region_name\n",
-    "spark._jsc.hadoopConfiguration().set('fs.s3a.endpoint', 's3.{}.amazonaws.com'.format(region))\n",
+    "endpoint_domain = 'com.cn' if region in cn_regions else 'com'",
+    "spark._jsc.hadoopConfiguration().set('fs.s3a.endpoint', 's3.{}.amazonaws.{}'.format(region, endpoint_domain))\n",
     "\n",
     "trainingData = spark.read.format('libsvm')\\\n",
     "    .option('numFeatures', '784')\\\n",

--- a/sagemaker-spark/pyspark_mnist/pyspark_mnist_xgboost.ipynb
+++ b/sagemaker-spark/pyspark_mnist/pyspark_mnist_xgboost.ipynb
@@ -96,8 +96,10 @@
    "source": [
     "import boto3\n",
     "\n",
+    "cn_regions = ['cn-north-1', 'cn-northwest-1']",
     "region = boto3.Session().region_name\n",
-    "spark._jsc.hadoopConfiguration().set('fs.s3a.endpoint', 's3.{}.amazonaws.com'.format(region))\n",
+    "endpoint_domain = 'com.cn' if region in cn_regions else 'com'",
+    "spark._jsc.hadoopConfiguration().set('fs.s3a.endpoint', 's3.{}.amazonaws.{}'.format(region, endpoint_domain))\n",
     "\n",
     "trainingData = spark.read.format('libsvm')\\\n",
     "    .option('numFeatures', '784')\\\n",


### PR DESCRIPTION
*Issue #, if available:*
In sagemaker-pyspark examples, Loading Data section hardcoded s3 endpoint domain to "amazonaws.com" however for cn regions, the domain should be "amazonaws.com.cn"

*Description of changes:*
Check boto region, if the region is "cn-north-1" or "cn-northwest-1", change endpoint domain to "amazonaws.com.cn"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
