### PR TITLE
Updated tf mnist model to generate single output to keep it compatible with the multiple output fix

### DIFF
--- a/sagemaker_neo_compilation_jobs/tensorflow_distributed_mnist/mnist.py
+++ b/sagemaker_neo_compilation_jobs/tensorflow_distributed_mnist/mnist.py
@@ -43,7 +43,6 @@ def model_fn(features, labels, mode, params):
 
     # Define operations
     if mode in (Modes.PREDICT, Modes.EVAL):
-        predicted_indices = tf.argmax(input=logits, axis=1)
         probabilities = tf.nn.softmax(logits, name='softmax_tensor')
 
     if mode in (Modes.TRAIN, Modes.EVAL):
@@ -55,7 +54,6 @@ def model_fn(features, labels, mode, params):
 
     if mode == Modes.PREDICT:
         predictions = {
-            'classes': predicted_indices,
             'probabilities': probabilities
         }
         export_outputs = {
@@ -71,7 +69,7 @@ def model_fn(features, labels, mode, params):
 
     if mode == Modes.EVAL:
         eval_metric_ops = {
-            'accuracy': tf.metrics.accuracy(label_indices, predicted_indices)
+            'accuracy': tf.metrics.accuracy(label_indices, tf.argmax(input=logits, axis=1))
         }
         return tf.estimator.EstimatorSpec(
             mode, loss=loss, eval_metric_ops=eval_metric_ops)
@@ -129,7 +127,7 @@ def neo_preprocess(payload, content_type):
 
     if content_type != 'application/x-image' and content_type != 'application/vnd+python.numpy+binary':
         raise RuntimeError('Content type must be application/x-image or application/vnd+python.numpy+binary')
-    
+
     f = io.BytesIO(payload)
     image = np.load(f)*255
 
@@ -142,7 +140,7 @@ def neo_postprocess(result):
     import json
 
     logging.info('Invoking user-defined post-processing function')
-    
+
     # Softmax (assumes batch size 1)
     result = np.squeeze(result)
     result_exp = np.exp(result - np.max(result))


### PR DESCRIPTION
This change would ensure that when we support multiple output  for tensorflow models the notebook will remain compatible.
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
