### PR TITLE
Fixing inference test images in semantic segmentation notebook

### DIFF
--- a/introduction_to_amazon_algorithms/semantic_segmentation_pascalvoc/semantic_segmentation_pascalvoc.ipynb
+++ b/introduction_to_amazon_algorithms/semantic_segmentation_pascalvoc/semantic_segmentation_pascalvoc.ipynb
@@ -468,7 +468,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget -O test.jpg https://images.pexels.com/photos/242829/pexels-photo-242829.jpeg\n",
+    "!wget -O test.jpg https://upload.wikimedia.org/wikipedia/commons/b/b4/R1200RT_in_Hongkong.jpg\n",
     "filename = 'test.jpg'"
    ]
   },


### PR DESCRIPTION
*Description of changes:*
- Fixing test image for inference as the old one was obsolete.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
