### PR TITLE
Use Python SDK function to get image URI in SKLearn E2E notebook

### DIFF
--- a/sagemaker-python-sdk/scikit_learn_randomforest/Sklearn_on_SageMaker_end2end.ipynb
+++ b/sagemaker-python-sdk/scikit_learn_randomforest/Sklearn_on_SageMaker_end2end.ipynb
@@ -319,7 +319,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When using `boto3` to launch a training job we must explicitly point to a docker image. Below we do a rudimentary function forming the ARN of a sklearn 0.20 CPU container for python 3"
+    "When using `boto3` to launch a training job we must explicitly point to a docker image."
    ]
   },
   {
@@ -328,28 +328,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "image_registry_map = {\n",
-    "    'us-west-1': '746614075791',\n",
-    "    'us-west-2': '246618743249',\n",
-    "    'us-east-1': '683313688378',\n",
-    "    'us-east-2': '257758044811',\n",
-    "    'ap-northeast-1': '354813040037',\n",
-    "    'ap-northeast-2': '366743142698',\n",
-    "    'ap-southeast-1': '121021644041',\n",
-    "    'ap-southeast-2': '783357654285',\n",
-    "    'ap-south-1': '720646828776',\n",
-    "    'eu-west-1': '141502667606',\n",
-    "    'eu-west-2': '764974769150',\n",
-    "    'eu-central-1': '492215442770',\n",
-    "    'ca-central-1': '341280168497',\n",
-    "    'us-gov-west-1': '414596584902',\n",
-    "    'us-iso-east-1': '833128469047',\n",
-    "}\n",
+    "from sagemaker.fw_registry import default_framework_uri\n",
     "\n",
-    "def container_arn(region):\n",
-    "    \n",
-    "    return (image_registry_map[region] + '.dkr.ecr.' + region \n",
-    "            + '.amazonaws.com/sagemaker-scikit-learn:0.20.0-cpu-py3')"
+    "training_image = default_framework_uri('scikit-learn', region, '0.20.0-cpu-py3')\n",
+    "print(training_image)"
    ]
   },
   {
@@ -371,7 +353,7 @@
     "        'sagemaker_submit_directory': 's3://' + bucket + '/' + project + '/' + source \n",
     "    },\n",
     "    AlgorithmSpecification={\n",
-    "        'TrainingImage': container_arn(region),\n",
+    "        'TrainingImage': training_image,\n",
     "        'TrainingInputMode': 'File',\n",
     "        'MetricDefinitions': [\n",
     "            {'Name': 'median-AE', 'Regex': 'AE-at-50th-percentile: ([0-9.]+).*$'},\n",


### PR DESCRIPTION
*Description of changes:*

This notebook will fail when a user runs the notebook in a region that is not in the list `image_registry_map`. This PR replaces the custom function for getting the image URI with a Python SDK function that serves the same purpose. The notebook doesn't have to be updated each time a new AWS region is launched because Python SDK is expected to updated with the new region information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
