### PR TITLE
Fix xgboost version in xgboost bring your own model notebook

### DIFF
--- a/advanced_functionality/xgboost_bring_your_own_model/xgboost_bring_your_own_model.ipynb
+++ b/advanced_functionality/xgboost_bring_your_own_model/xgboost_bring_your_own_model.ipynb
@@ -44,7 +44,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "isConfigCell": true
    },
    "outputs": [],
@@ -55,26 +54,26 @@
     "import boto3\n",
     "import re\n",
     "import json\n",
+    "import sagemaker\n",
     "from sagemaker import get_execution_role\n",
     "\n",
     "region = boto3.Session().region_name\n",
     "\n",
     "role = get_execution_role()\n",
     "\n",
-    "bucket='<s3 bucket>' # put your s3 bucket name here, and create s3 bucket"
+    "bucket = sagemaker.Session().default_bucket()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "isConfigCell": true
    },
    "outputs": [],
    "source": [
     "prefix = 'sagemaker/DEMO-xgboost-byo'\n",
-    "bucket_path = 'https://s3-{}.amazonaws.com/{}'.format(region,bucket)\n",
+    "bucket_path = 'https://s3-{}.amazonaws.com/{}'.format(region, bucket)\n",
     "# customize to your bucket where you have stored the data"
    ]
   },
@@ -93,12 +92,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "!conda install -y -c conda-forge xgboost"
+    "!conda install -y -c conda-forge xgboost==0.90"
    ]
   },
   {
@@ -111,9 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -136,9 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -159,9 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "train_set, valid_set, test_set = get_dataset()\n",
@@ -186,9 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import xgboost as xgb\n",
@@ -214,9 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "model_file_name = \"DEMO-local-xgboost-model\"\n",
@@ -226,9 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!tar czvf model.tar.gz $model_file_name"
@@ -244,9 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fObj = open(\"model.tar.gz\", 'rb')\n",
@@ -267,21 +250,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
-    "container = get_image_uri(boto3.Session().region_name, 'xgboost')"
+    "container = get_image_uri(boto3.Session().region_name, 'xgboost', '0.90-2')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -318,9 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from time import gmtime, strftime\n",
@@ -350,9 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -390,9 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "runtime_client = boto3.client('runtime.sagemaker')"
@@ -408,9 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -423,9 +394,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -455,9 +424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "floatArr = np.array(json.loads(result))\n",
@@ -478,13 +445,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sm_client.delete_endpoint(EndpointName=endpoint_name)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -504,7 +476,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.7"
   },
   "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },


### PR DESCRIPTION
*Description of changes:*

- Use `sagemaker.default_bucket()` rather than have the user specify bucket name.
- This notebook trains an XGBoost model locally, uploads the model file to S3, and uses SM container. Since XGBoost recently released 1.0, running `conda install xgboost` without specifying version will install 1.0, while the container will have either XGBoost 0.72 or 0.90. This results in an error (and an empty prediction) when endpoint is called. This PR fixes the conda version to 0.90, i.e., `conda install xgboost==0.90`.
- Use the latest 0.90-2 version in `get_image_uri()`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
