### PR TITLE
Add missing read() calls to usages of invoke_endpoint()

### DIFF
--- a/aws_sagemaker_studio/getting_started/xgboost_customer_churn_studio.ipynb
+++ b/aws_sagemaker_studio/getting_started/xgboost_customer_churn_studio.ipynb
@@ -858,6 +858,7 @@
     "            response = runtime_client.invoke_endpoint(EndpointName=ep_name,\n",
     "                                          ContentType='text/csv', \n",
     "                                          Body=payload)\n",
+    "            response['Body'].read()\n",
     "            sleep(1)\n",
     "            \n",
     "def invoke_endpoint_forever():\n",

--- a/reinforcement_learning/rl_game_server_autopilot/sagemaker/rl_gamerserver_ray.ipynb
+++ b/reinforcement_learning/rl_game_server_autopilot/sagemaker/rl_gamerserver_ray.ipynb
@@ -869,8 +869,8 @@
     "      ContentType=content_type,\n",
     "      Accept=accept,\n",
     "      Body=last_observations\n",
-    "    )",
-    "response['Body'].read()\n"
+    "    )\n",
+    "response['Body'].read()"
    ]
   },
   {

--- a/reinforcement_learning/rl_game_server_autopilot/sagemaker/rl_gamerserver_ray.ipynb
+++ b/reinforcement_learning/rl_game_server_autopilot/sagemaker/rl_gamerserver_ray.ipynb
@@ -869,7 +869,8 @@
     "      ContentType=content_type,\n",
     "      Accept=accept,\n",
     "      Body=last_observations\n",
-    "    )"
+    "    )",
+    "response['Body'].read()\n"
    ]
   },
   {

--- a/sagemaker_model_monitor/introduction/SageMaker-ModelMonitoring.ipynb
+++ b/sagemaker_model_monitor/introduction/SageMaker-ModelMonitoring.ipynb
@@ -508,6 +508,7 @@
     "            response = runtime_client.invoke_endpoint(EndpointName=ep_name,\n",
     "                                          ContentType='text/csv', \n",
     "                                          Body=payload)\n",
+    "            response['Body'].read()\n",
     "            time.sleep(1)\n",
     "            \n",
     "def invoke_endpoint_forever():\n",


### PR DESCRIPTION
If the response body is not fully consumed with read(), then
the underlying connection will not be made available for reuse
(at least in a timely or predictable manner). This call was
missing in places where we don't actually care about the body
content.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
