### PR TITLE
Fix scikit-image version with the numpy version used in notebook

### DIFF
--- a/hyperparameter_tuning/mxnet_gluon_cifar10_random_search/hyperparameter_tuning_mxnet_gluon_cifar10_random_search.ipynb
+++ b/hyperparameter_tuning/mxnet_gluon_cifar10_random_search/hyperparameter_tuning_mxnet_gluon_cifar10_random_search.ipynb
@@ -36,9 +36,14 @@
     "\n",
     "SageMaker's Automatic Model Tuning works with SageMaker's built-in algorithms, pre-built deep learning frameworks, and the bring your own algorithm container options.  But, for this example, let's stick with the MXNet framework, a ResNet-34 convolutional neural network, and the [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) image dataset.  For more background, please see the [MXNet CIFAR-10 example notebook](https://github.com/awslabs/amazon-sagemaker-examples/blob/master/sagemaker-python-sdk/mxnet_gluon_cifar10/mxnet_cifar10_with_gluon.ipynb).\n",
     "\n",
-    "## Setup\n",
-    "\n",
-    "Specify the IAM role for permission to access the dataset in S3 and SageMaker functionality."
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Install scikit-image==0.14.2"
    ]
   },
   {
@@ -50,6 +55,13 @@
     "# Install a scikit-image package in the current Jupyter kernel\n",
     "import sys\n",
     "!{sys.executable} -m pip install scikit-image==0.14.2 "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Specify the IAM role for permission to access the dataset in S3 and SageMaker functionality."
    ]
   },
   {

--- a/hyperparameter_tuning/mxnet_gluon_cifar10_random_search/hyperparameter_tuning_mxnet_gluon_cifar10_random_search.ipynb
+++ b/hyperparameter_tuning/mxnet_gluon_cifar10_random_search/hyperparameter_tuning_mxnet_gluon_cifar10_random_search.ipynb
@@ -47,6 +47,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Install a scikit-image package in the current Jupyter kernel\n",
+    "import sys\n",
+    "!{sys.executable} -m pip install scikit-image==0.14.2 "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import sagemaker\n",
     "\n",
     "sagemaker_session = sagemaker.Session()\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Scikit-image is not compatible with the numpy version 1.16.4 which is used in SageMaker Notebook. More about this issue: https://github.com/scikit-image/scikit-image/issues/3649 This fix will install scikit-image 0.14.2 which works with numpy 1.16.4. Tested in us-west-2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
