### PR TITLE
Fix hpo pytorch framework version

### DIFF
--- a/hyperparameter_tuning/pytorch_mnist/hpo_pytorch_mnist.ipynb
+++ b/hyperparameter_tuning/pytorch_mnist/hpo_pytorch_mnist.ipynb
@@ -173,7 +173,7 @@
     "\n",
     "estimator = PyTorch(entry_point=\"mnist.py\",\n",
     "                    role=role,\n",
-    "                    framework_version='1.0.0.dev',\n",
+    "                    framework_version='1.0.0',\n",
     "                    train_instance_count=1,\n",
     "                    train_instance_type='ml.m4.xlarge',\n",
     "                    hyperparameters={\n",

--- a/hyperparameter_tuning/pytorch_mnist/mnist.py
+++ b/hyperparameter_tuning/pytorch_mnist/mnist.py
@@ -40,7 +40,7 @@ class Net(nn.Module):
 
 def _get_train_data_loader(batch_size, training_dir, is_distributed, **kwargs):
     logger.info("Get train data loader")
-    dataset = datasets.MNIST(training_dir, train=True, transform=transforms.Compose([
+    dataset = datasets.MNIST(training_dir, download=True, train=True, transform=transforms.Compose([
         transforms.ToTensor(),
         transforms.Normalize((0.1307,), (0.3081,))
     ]))
@@ -52,7 +52,7 @@ def _get_train_data_loader(batch_size, training_dir, is_distributed, **kwargs):
 def _get_test_data_loader(test_batch_size, training_dir, **kwargs):
     logger.info("Get test data loader")
     return torch.utils.data.DataLoader(
-        datasets.MNIST(training_dir, train=False, transform=transforms.Compose([
+        datasets.MNIST(training_dir, download=True, train=False, transform=transforms.Compose([
             transforms.ToTensor(),
             transforms.Normalize((0.1307,), (0.3081,))
         ])),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Notebook fails with "framework_version='1.0.0.dev'" and we should move to framework_version-1.0.0. Change tested in us-west-2. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
