### PR TITLE
Add PyTorch notebook for SageMaker Studio

### DIFF
--- a/aws_sagemaker_studio/frameworks/pytorch_cnn_cifar10/cifar_utils.py
+++ b/aws_sagemaker_studio/frameworks/pytorch_cnn_cifar10/cifar_utils.py
@@ -1,0 +1,36 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+import torchvision
+import torchvision.transforms as transforms
+
+classes = ('plane', 'car', 'bird', 'cat', 'deer', 'dog', 'frog', 'horse', 'ship', 'truck')
+
+
+def _get_transform():
+    return torchvision.transforms.Compose(
+        [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
+    )
+
+
+def train_data_loader():
+    transform = _get_transform()
+    trainset = torchvision.datasets.CIFAR10(root='./data', train=True,
+                                            download=False, transform=transform)
+    return torch.utils.data.DataLoader(trainset, batch_size=4,
+                                       shuffle=True, num_workers=2)
+
+
+def test_data_loader():
+    transform = _get_transform()
+    testset = torchvision.datasets.CIFAR10(root='./data', train=False,
+                                           download=False, transform=transform)
+    return torch.utils.data.DataLoader(testset, batch_size=4,
+                                       shuffle=False, num_workers=2)
+
+
+def show_img(img):
+    """displays an image"""
+    img = img / 2 + 0.5  # unnormalize
+    npimg = img.numpy()
+    plt.imshow(np.transpose(npimg, (1, 2, 0)))

--- a/aws_sagemaker_studio/frameworks/pytorch_cnn_cifar10/cifar_utils.py
+++ b/aws_sagemaker_studio/frameworks/pytorch_cnn_cifar10/cifar_utils.py
@@ -1,3 +1,15 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
 import matplotlib.pyplot as plt
 import numpy as np
 import torch

--- a/aws_sagemaker_studio/frameworks/pytorch_cnn_cifar10/pytorch_cnn_cifar10.ipynb
+++ b/aws_sagemaker_studio/frameworks/pytorch_cnn_cifar10/pytorch_cnn_cifar10.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "*(This notebook was tested with the \"Python 3 (PyTorch CPU Optimized)\" kernel.)*\n",
     "\n",
-    "Amazon SageMaker is a fully managed service that provides developers and data scientists with the ability to build, train, and deploy machine learning (ML) models quickly. Amazon SageMaker removes the heavy lifting from each step of the machine learning process to make it easier to develop high-quality models. The SageMaker Python SDK provides open source APIs and containers that make it easy to train and deploy models in Amazon SageMaker with several different machine learning and deep learning frameworks, including PyTorch.\n",
+    "Amazon SageMaker is a fully managed service that provides developers and data scientists with the ability to build, train, and deploy machine learning (ML) models quickly. Amazon SageMaker removes the heavy lifting from each step of the machine learning process to make it easier to develop high-quality models. The SageMaker Python SDK makes it easy to train and deploy models in Amazon SageMaker with several different machine learning and deep learning frameworks, including PyTorch.\n",
     "\n",
     "In this notebook, we use Amazon SageMaker to train a convolutional neural network using PyTorch and the [CIFAR-10 dataset](https://www.cs.toronto.edu/~kriz/cifar.html), and then we host the model in Amazon SageMaker for inference."
    ]

--- a/aws_sagemaker_studio/frameworks/pytorch_cnn_cifar10/pytorch_cnn_cifar10.ipynb
+++ b/aws_sagemaker_studio/frameworks/pytorch_cnn_cifar10/pytorch_cnn_cifar10.ipynb
@@ -1,0 +1,334 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Training and Hosting a PyTorch model in Amazon SageMaker\n",
+    "\n",
+    "*(This notebook was tested with the \"Python 3 (PyTorch CPU Optimized)\" kernel.)*\n",
+    "\n",
+    "Amazon SageMaker is a fully managed service that provides developers and data scientists with the ability to build, train, and deploy machine learning (ML) models quickly. Amazon SageMaker removes the heavy lifting from each step of the machine learning process to make it easier to develop high-quality models. The SageMaker Python SDK provides open source APIs and containers that make it easy to train and deploy models in Amazon SageMaker with several different machine learning and deep learning frameworks, including PyTorch.\n",
+    "\n",
+    "In this notebook, we use Amazon SageMaker to train a convolutional neural network using PyTorch and the [CIFAR-10 dataset](https://www.cs.toronto.edu/~kriz/cifar.html), and then we host the model in Amazon SageMaker for inference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Let's start by specifying:\n",
+    "\n",
+    "- An Amazon S3 bucket and prefix for training and model data. This should be in the same region used for SageMaker Studio, training, and hosting.\n",
+    "- An IAM role for SageMaker to access to your training and model data. If you wish to use a different role than the one set up for SageMaker Studio, replace `sagemaker.get_execution_role()` with the appropriate IAM role or ARN. For more about using IAM roles with SageMaker, see [the AWS documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-roles.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sagemaker\n",
+    "\n",
+    "sagemaker_session = sagemaker.Session()\n",
+    "\n",
+    "bucket = sagemaker_session.default_bucket()\n",
+    "prefix = 'pytorch-cnn-cifar10-example'\n",
+    "\n",
+    "role = sagemaker.get_execution_role()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare the training data\n",
+    "\n",
+    "The [CIFAR-10 dataset](https://www.cs.toronto.edu/~kriz/cifar.html) is a subset of the [80 million tiny images dataset](https://people.csail.mit.edu/torralba/tinyimages). It consists of 60,000 32x32 color images in 10 classes, with 6,000 images per class."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Download the data\n",
+    "\n",
+    "First we download the dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "wget https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz\n",
+    "tar xfvz cifar-10-python.tar.gz\n",
+    "\n",
+    "mkdir data\n",
+    "mv cifar-10-batches-py data/.\n",
+    "\n",
+    "rm cifar-10-python.tar.gz"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After downloading the dataset, we use the [`torchvision.datasets` module](https://pytorch.org/docs/stable/torchvision/datasets.html) to load the CIFAR-10 dataset, utilizing the [`torchvision.transforms` module](https://pytorch.org/docs/stable/torchvision/transforms.html) to convert the data into normalized tensor images:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cifar_utils import classes, show_img, train_data_loader, test_data_loader\n",
+    "\n",
+    "train_loader = train_data_loader()\n",
+    "test_loader = test_data_loader()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Preview the data\n",
+    "\n",
+    "Now we can view some of data we have prepared:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import torchvision, torch\n",
+    "\n",
+    "# get some random training images\n",
+    "dataiter = iter(train_loader)\n",
+    "images, labels = dataiter.next()\n",
+    "\n",
+    "# show images\n",
+    "show_img(torchvision.utils.make_grid(images))\n",
+    "\n",
+    "# print labels\n",
+    "print(' '.join('%9s' % classes[labels[j]] for j in range(4)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Upload the data\n",
+    "We use the `sagemaker.s3.S3Uploader` to upload our dataset to Amazon S3. The return value `inputs` identifies the location -- we use this later for the training job."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.s3 import S3Uploader\n",
+    "\n",
+    "inputs = S3Uploader.upload('data', 's3://{}/{}/data'.format(bucket, prefix))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare the entry-point script\n",
+    "\n",
+    "When SageMaker trains and hosts our model, it runs a Python script that we provide. (This is run as the entry point of a Docker container.) For training, this script contains the PyTorch code needed for the model to learn from our dataset. For inference, the code is for loading the model and processing the prediction input. For convenience, we put both the training and inference code in the same file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Training\n",
+    "\n",
+    "The training code is very similar to a training script we might run outside of Amazon SageMaker, but we can access useful properties about the training environment through various environment variables. For this notebook, our script retrieves the following environment variable values:\n",
+    "\n",
+    "* `SM_HOSTS`: a list of hosts on the container network.\n",
+    "* `SM_CURRENT_HOST`: the name of the current container on the container network.\n",
+    "* `SM_MODEL_DIR`: the location for model artifacts. This directory is uploaded to Amazon S3 at the end of the training job.\n",
+    "* `SM_CHANNEL_TRAINING`: the location of our training data.\n",
+    "* `SM_NUM_GPUS`: the number of GPUs available to the current container.\n",
+    "\n",
+    "We also use a main guard (`if __name__=='__main__':`) to ensure that our training code is executed only for training, as SageMaker imports the entry-point script.\n",
+    "\n",
+    "For more about writing a PyTorch training script with SageMaker, please see the [SageMaker documentation](https://sagemaker.readthedocs.io/en/stable/using_pytorch.html#prepare-a-pytorch-training-script)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Inference\n",
+    "\n",
+    "For inference, we need to implement a few specific functions to tell SageMaker how to load our model and handle prediction input.\n",
+    "\n",
+    "* `model_fn(model_dir)`: loads the model from disk. This function must be implemented.\n",
+    "* `input_fn(serialized_input_data, content_type)`: deserializes the prediction input.\n",
+    "* `predict_fn(input_data, model)`: calls the model on the deserialized data.\n",
+    "* `output_fn(prediction_output, accept)`: serializes the prediction output.\n",
+    "\n",
+    "The last three functions - `input_fn`, `predict_fn`, and `output_fn` - are optional because SageMaker has default implementations to handle common content types. However, there is no default implementation of `model_fn` for PyTorch models on SageMaker, so our script has to implement `model_fn`.\n",
+    "\n",
+    "For more about PyTorch inference with SageMaker, please see the [SageMaker documentation](https://sagemaker.readthedocs.io/en/stable/using_pytorch.html#id3)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Put it all together\n",
+    "\n",
+    "Here is the full script for both training and hosting our convolutional neural network:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pygmentize source/cifar10.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run a SageMaker training job\n",
+    "\n",
+    "The SageMaker Python SDK makes it easy for us to interact with SageMaker. Here, we use the `PyTorch` estimator class to start a training job. We configure it with the following parameters:\n",
+    "\n",
+    "* `entry_point`: our training script.\n",
+    "* `role`: an IAM role that SageMaker uses to access training and model data.\n",
+    "* `framework_version`: the PyTorch version we wish to use. For a list of supported versions, see [here](https://github.com/aws/sagemaker-python-sdk#pytorch-sagemaker-estimators).\n",
+    "* `train_instance_count`: the number of training instances.\n",
+    "* `train_instance_type`: the training instance type. For a list of supported instance types, see [the AWS Documentation](https://aws.amazon.com/sagemaker/pricing/instance-types/).\n",
+    "\n",
+    "Once we our `PyTorch` estimator, we start a training job by calling `fit()` and passing the training data we uploaded to S3 earlier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sagemaker.pytorch import PyTorch\n",
+    "\n",
+    "estimator = PyTorch(entry_point='source/cifar10.py',\n",
+    "                    role=role,\n",
+    "                    framework_version='1.4.0',\n",
+    "                    train_instance_count=1,\n",
+    "                    train_instance_type='ml.c5.xlarge')\n",
+    "\n",
+    "estimator.fit(inputs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Deploy the model for inference\n",
+    "\n",
+    "After we train our model, we can deploy it to a SageMaker Endpoint, which serves prediction requests in real-time. To do so, we simply call `deploy()` on our estimator, passing in the desired number of instances and instance type for the endpoint:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictor = estimator.deploy(initial_instance_count=1, instance_type='ml.c5.xlarge')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Invoke the endpoint\n",
+    "\n",
+    "We then use the returned `predictor` object to invoke our endpoint. For demonstration purposes, we also print out the image, its original label, and its predicted label."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get some test images\n",
+    "dataiter = iter(test_loader)\n",
+    "images, labels = dataiter.next()\n",
+    "\n",
+    "# print images, labels, and predictions\n",
+    "show_img(torchvision.utils.make_grid(images))\n",
+    "print('GroundTruth: ', ' '.join('%4s' % classes[labels[j]] for j in range(4)))\n",
+    "\n",
+    "outputs = predictor.predict(images.numpy())\n",
+    "\n",
+    "_, predicted = torch.max(torch.from_numpy(np.array(outputs)), 1)\n",
+    "\n",
+    "print('Predicted:   ', ' '.join('%4s' % classes[predicted[j]] for j in range(4)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup\n",
+    "\n",
+    "Once finished, we delete our endpoint to release the instances (and avoid incurring extra costs)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictor.delete_endpoint()"
+   ]
+  }
+ ],
+ "metadata": {
+  "instance_type": "ml.t3.medium",
+  "kernelspec": {
+   "display_name": "Python 3 (PyTorch CPU Optimized)",
+   "language": "python",
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-2:429704687514:image/pytorch-1.4-cpu-py36"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  },
+  "notice": "Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/aws_sagemaker_studio/frameworks/pytorch_cnn_cifar10/source/cifar10.py
+++ b/aws_sagemaker_studio/frameworks/pytorch_cnn_cifar10/source/cifar10.py
@@ -1,3 +1,15 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
 import argparse
 import json
 import logging

--- a/aws_sagemaker_studio/frameworks/pytorch_cnn_cifar10/source/cifar10.py
+++ b/aws_sagemaker_studio/frameworks/pytorch_cnn_cifar10/source/cifar10.py
@@ -1,0 +1,154 @@
+import argparse
+import json
+import logging
+import os
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.nn.parallel
+import torch.optim
+import torch.utils.data
+import torch.utils.data.distributed
+import torchvision
+import torchvision.models
+import torchvision.transforms as transforms
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+classes = ('plane', 'car', 'bird', 'cat', 'deer', 'dog', 'frog', 'horse', 'ship', 'truck')
+
+
+# https://github.com/pytorch/tutorials/blob/master/beginner_source/blitz/cifar10_tutorial.py#L118
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.fc1 = nn.Linear(16 * 5 * 5, 120)
+        self.fc2 = nn.Linear(120, 84)
+        self.fc3 = nn.Linear(84, 10)
+
+    def forward(self, x):
+        x = self.pool(F.relu(self.conv1(x)))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = x.view(-1, 16 * 5 * 5)
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        x = self.fc3(x)
+        return x
+
+
+def _train(args):
+    is_distributed = len(args.hosts) > 1 and args.dist_backend is not None
+    logger.debug('Distributed training - {}'.format(is_distributed))
+
+    if is_distributed:
+        # Initialize the distributed environment.
+        world_size = len(args.hosts)
+        os.environ['WORLD_SIZE'] = str(world_size)
+        host_rank = args.hosts.index(args.current_host)
+        os.environ['RANK'] = str(host_rank)
+        dist.init_process_group(backend=args.dist_backend, rank=host_rank, world_size=world_size)
+        logger.info(
+            'Initialized the distributed environment: \'{}\' backend on {} nodes. '.format(
+                args.dist_backend,
+                dist.get_world_size()) + 'Current host rank is {}. Using cuda: {}. Number of gpus: {}'.format(
+                dist.get_rank(), torch.cuda.is_available(), args.num_gpus))
+
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    logger.info('Device Type: {}'.format(device))
+
+    logger.info('Loading Cifar10 dataset')
+    transform = transforms.Compose(
+        [transforms.ToTensor(),
+         transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
+
+    trainset = torchvision.datasets.CIFAR10(root=args.data_dir, train=True,
+                                            download=False, transform=transform)
+    train_loader = torch.utils.data.DataLoader(trainset, batch_size=args.batch_size,
+                                               shuffle=True, num_workers=args.workers)
+
+    logger.info('Model loaded')
+    model = Net()
+
+    if torch.cuda.device_count() > 1:
+        logger.info('Gpu count: {}'.format(torch.cuda.device_count()))
+        model = nn.DataParallel(model)
+
+    model = model.to(device)
+
+    criterion = nn.CrossEntropyLoss().to(device)
+    optimizer = torch.optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum)
+
+    for epoch in range(0, args.epochs):
+        running_loss = 0.0
+        for i, data in enumerate(train_loader):
+            # get the inputs
+            inputs, labels = data
+            inputs, labels = inputs.to(device), labels.to(device)
+
+            # zero the parameter gradients
+            optimizer.zero_grad()
+
+            # forward + backward + optimize
+            outputs = model(inputs)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+            # print statistics
+            running_loss += loss.item()
+            if i % 2000 == 1999:  # print every 2000 mini-batches
+                print('[%d, %5d] loss: %.3f' %
+                      (epoch + 1, i + 1, running_loss / 2000))
+                running_loss = 0.0
+
+    print('Finished Training')
+    return _save_model(model, args.model_dir)
+
+
+def _save_model(model, model_dir):
+    logger.info('Saving the model.')
+    path = os.path.join(model_dir, 'model.pth')
+    # recommended way from http://pytorch.org/docs/master/notes/serialization.html
+    torch.save(model.cpu().state_dict(), path)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--workers', type=int, default=2, metavar='W',
+                        help='number of data loading workers (default: 2)')
+    parser.add_argument('--epochs', type=int, default=2, metavar='E',
+                        help='number of total epochs to run (default: 2)')
+    parser.add_argument('--batch_size', type=int, default=4, metavar='BS',
+                        help='batch size (default: 4)')
+    parser.add_argument('--lr', type=float, default=0.001, metavar='LR',
+                        help='initial learning rate (default: 0.001)')
+    parser.add_argument('--momentum', type=float, default=0.9, metavar='M', help='momentum (default: 0.9)')
+    parser.add_argument('--dist_backend', type=str, default='gloo', help='distributed backend (default: gloo)')
+
+    parser.add_argument('--hosts', type=json.loads, default=os.environ['SM_HOSTS'])
+    parser.add_argument('--current-host', type=str, default=os.environ['SM_CURRENT_HOST'])
+    parser.add_argument('--model-dir', type=str, default=os.environ['SM_MODEL_DIR'])
+    parser.add_argument('--data-dir', type=str, default=os.environ['SM_CHANNEL_TRAINING'])
+    parser.add_argument('--num-gpus', type=int, default=os.environ['SM_NUM_GPUS'])
+
+    _train(parser.parse_args())
+
+
+def model_fn(model_dir):
+    logger.info('model_fn')
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    model = Net()
+    if torch.cuda.device_count() > 1:
+        logger.info('Gpu count: {}'.format(torch.cuda.device_count()))
+        model = nn.DataParallel(model)
+
+    with open(os.path.join(model_dir, 'model.pth'), 'rb') as f:
+        model.load_state_dict(torch.load(f))
+    return model.to(device)

--- a/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist_with_batch_transform.ipynb
+++ b/sagemaker-python-sdk/mxnet_mnist/mxnet_mnist_with_batch_transform.ipynb
@@ -355,7 +355,7 @@
    "pygments_lexer": "ipython3",
    "version": "3.6.4"
   },
-  "notice": "Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+  "notice": "Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved. Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },
  "nbformat": 4,
  "nbformat_minor": 2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This was more of a rewrite than a copy (as compared to #1178, #1179, and #1180), so I chose not to backport the changes to the original PyTorch CIFAR-10 Local Mode notebook.

The extra step of downloading the dataset without using `torchvision.datasets` to do so is because SageMaker Studio doesn't yet come with `ipywidgets` pre-installed in the PyTorch kernel, and that library is needed for `torchvision.datasets` to download while in a notebook.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
