### PR TITLE
Resolved all FutureWarnings of Panda in Deepar Introduction Notebook

### DIFF
--- a/introduction_to_amazon_algorithms/deepar_synthetic/deepar_synthetic.ipynb
+++ b/introduction_to_amazon_algorithms/deepar_synthetic/deepar_synthetic.ipynb
@@ -202,7 +202,7 @@
     "    source = level + seas_amplitude*np.sin(time_ticks*(2*np.pi)/period)\n",
     "    noise = sig*np.random.randn(data_length)\n",
     "    data = source + noise\n",
-    "    index = pd.DatetimeIndex(start=t0, freq=freq, periods=data_length)\n",
+    "    index = pd.date_range(start=t0, freq=freq, periods=data_length)\n",
     "    time_series.append(pd.Series(data=data, index=index))"
    ]
   },
@@ -480,7 +480,7 @@
     "        \n",
     "        Return value: list of `pandas.DataFrame` objects, each containing the predictions\n",
     "        \"\"\"\n",
-    "        prediction_times = [x.index[-1]+1 for x in ts]\n",
+    "        prediction_times = [x.index[-1]+pd.Timedelta(1, unit=self.freq) for x in ts]\n",
     "        req = self.__encode_request(ts, cat, encoding, num_samples, quantiles)\n",
     "        res = super(DeepARPredictor, self).predict(req)\n",
     "        return self.__decode_response(res, prediction_times, encoding)\n",
@@ -495,7 +495,7 @@
     "        response_data = json.loads(response.decode(encoding))\n",
     "        list_of_df = []\n",
     "        for k in range(len(prediction_times)):\n",
-    "            prediction_index = pd.DatetimeIndex(start=prediction_times[k], freq=self.freq, periods=self.prediction_length)\n",
+    "            prediction_index = pd.date_range(start=prediction_times[k], freq=self.freq, periods=self.prediction_length)\n",
     "            list_of_df.append(pd.DataFrame(data=response_data['predictions'][k]['quantiles'], index=prediction_index))\n",
     "        return list_of_df"
    ]


### PR DESCRIPTION
*Issue #, if available:*
[#1218](https://github.com/awslabs/amazon-sagemaker-examples/issues/1218)

*Description of changes:*
[The Deepar Introduction Notebook](https://github.com/awslabs/amazon-sagemaker-examples/blob/master/introduction_to_amazon_algorithms/deepar_synthetic/deepar_synthetic.ipynb) emitted three Pandas Future Warnings:

    FutureWarning: Creating a DatetimeIndex by passing range endpoints is deprecated. Use pandas.date_range instead.

twice, and:

    FutureWarning: Addition/subtraction of integers and integer-arrays to Timestamp is deprecated, will be removed in a future version.  Instead of adding/subtracting `n`, use `n * self.freq`

Since we insist on the highest standards, I took the liberty to resolve them, by replacing `pd.DatetimeIndex()` with `pd.date_range()`

and also

use `pd.Timedelta(1, unit=self.freq)` to increment the Timestamp, instead of just adding 1. Note that I used the frequency to dynamically select the unit (instead of statically passing the `hours=1` parameter), since in the top cells, the user defines `freq` as `'H'`, but if somebody changed that locally, then that change would not be reflected in the prediction code (which applies that increment).

I checked all the Notebook's cells after my changes, and everything worked as before (except from the warnings obviously), results were the same.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
