### PR TITLE
XGBoost abalone: Update to use 1.0-1

### DIFF
--- a/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
@@ -188,7 +188,7 @@
    "outputs": [],
    "source": [
     "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
-    "container = get_image_uri(region, 'xgboost', '0.90-1')"
+    "container = get_image_uri(region, 'xgboost', '1.0-1')"
    ]
   },
   {

--- a/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone_dist_script_mode.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone_dist_script_mode.ipynb
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ensure sagemaker version >= 1.35.0\n",
+    "# ensure sagemaker version >= 1.56.3\n",
     "!pip show sagemaker"
    ]
   },
@@ -400,7 +400,7 @@
     "\n",
     "xgb_script_mode_estimator = XGBoost(\n",
     "    entry_point=script_path,\n",
-    "    framework_version='0.90-1', # Note: framework_version is mandatory\n",
+    "    framework_version='1.0-1', # Note: framework_version is mandatory\n",
     "    hyperparameters=hyperparams,\n",
     "    role=role,\n",
     "    train_instance_count=2, \n",

--- a/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_managed_spot_training.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_managed_spot_training.ipynb
@@ -85,7 +85,7 @@
    "outputs": [],
    "source": [
     "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
-    "container = get_image_uri(region, 'xgboost', '0.90-1')"
+    "container = get_image_uri(region, 'xgboost', '1.0-1')"
    ]
   },
   {


### PR DESCRIPTION
*Description of changes:*

Update XGBoost abalone notebooks to use the latest (`1.0-1`) version. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
