### PR TITLE
pandas upstream changed as_matrix to to_numpy

### DIFF
--- a/introduction_to_amazon_algorithms/random_cut_forest/random_cut_forest.ipynb
+++ b/introduction_to_amazon_algorithms/random_cut_forest/random_cut_forest.ipynb
@@ -256,7 +256,7 @@
     "                      num_trees=50)\n",
     "\n",
     "# automatically upload the training data to S3 and run the training job\n",
-    "rcf.fit(rcf.record_set(taxi_data.value.as_matrix().reshape(-1,1)))"
+    "rcf.fit(rcf.record_set(taxi_data.value.to_numpy().reshape(-1,1)))"
    ]
   },
   {
@@ -360,7 +360,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "taxi_data_numpy = taxi_data.value.as_matrix().reshape(-1,1)\n",
+    "taxi_data_numpy = taxi_data.value.to_numpy().reshape(-1,1)\n",
     "print(taxi_data_numpy[:6])\n",
     "results = rcf_inference.predict(taxi_data_numpy[:6])"
    ]


### PR DESCRIPTION
Pandas library changed recently, this is necessary for this lab to run with current pandas in sagemaker studio, further discussion at  https://stackoverflow.com/questions/60164560/attributeerror-series-object-has-no-attribute-as-matrix-why-is-it-error

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
