### PR TITLE
Pull Request to fix - SageMaker Xgboost 1.0-1 not found with older SageMaker SDK #1285

### DIFF
--- a/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb
@@ -27,8 +27,30 @@
     "## Introduction\n",
     "\n",
     "This notebook demonstrates the use of Amazon SageMaker’s implementation of the XGBoost algorithm to train and host a regression model. We use the [Abalone data](https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/regression.html) originally from the [UCI data repository](https://archive.ics.uci.edu/ml/datasets/abalone). More details about the original dataset can be found [here](https://archive.ics.uci.edu/ml/machine-learning-databases/abalone/abalone.names).  In the libsvm converted [version](https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/regression.html), the nominal feature (Male/Female/Infant) has been converted into a real valued feature. Age of abalone is to be predicted from eight physical measurements.  \n",
-    "\n",
-    "---\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "Ensuring the latest sagemaker sdk is installed. For a major version upgrade, there might be some apis that may get deprecated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -qU awscli boto3 sagemaker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Setup\n",
     "\n",
     "\n",

--- a/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone_dist_script_mode.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone_dist_script_mode.ipynb
@@ -47,8 +47,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ensure sagemaker version >= 1.56.3\n",
-    "!pip show sagemaker"
+    "# ensure sagemaker version >= 1.65.1\n",
+    "!pip install -qU awscli boto3 sagemaker"
    ]
   },
   {

--- a/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_managed_spot_training.ipynb
+++ b/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_managed_spot_training.ipynb
@@ -22,6 +22,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Prerequisites\n",
+    "Ensuring the latest sagemaker sdk is installed. For a major version upgrade, there might be some apis that may get deprecated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -qU awscli boto3 sagemaker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Setup variables and define functions"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*
Issue #1285

*Description of changes:*
Added a line to install latest sagemaker SDK in these notebooks so that latest SageMaker xgboost Docker image v1.0-1 can we fetched.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
