### PR TITLE
Fixing scipy install to use official recommendation

### DIFF
--- a/ground_truth_labeling_jobs/3d_point_cloud_input_data_processing/3D-point-cloud-input-data-processing.ipynb
+++ b/ground_truth_labeling_jobs/3d_point_cloud_input_data_processing/3D-point-cloud-input-data-processing.ipynb
@@ -270,7 +270,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade scipy"
+    "!python -m pip install --user numpy scipy"
    ]
   },
   {


### PR DESCRIPTION
Installing pip with scipy was causing issues in some Amazon SageMaker notebook instances. Using the official guidance found here for scipy installation: https://www.scipy.org/install.html#pip-install