### PR TITLE
Remove deprecated method call as_matrix

### DIFF
--- a/introduction_to_applying_machine_learning/linear_time_series_forecast/linear_time_series_forecast.ipynb
+++ b/introduction_to_applying_machine_learning/linear_time_series_forecast/linear_time_series_forecast.ipynb
@@ -228,11 +228,11 @@
     "split_test = int(len(gas) * 0.8)\n",
     "\n",
     "train_y = gas['thousands_barrels'][:split_train]\n",
-    "train_X = gas.drop('thousands_barrels', axis=1).iloc[:split_train, ].as_matrix()\n",
+    "train_X = gas.drop('thousands_barrels', axis=1).iloc[:split_train, ].to_numpy()\n",
     "validation_y = gas['thousands_barrels'][split_train:split_test]\n",
-    "validation_X = gas.drop('thousands_barrels', axis=1).iloc[split_train:split_test, ].as_matrix()\n",
+    "validation_X = gas.drop('thousands_barrels', axis=1).iloc[split_train:split_test, ].to_numpy()\n",
     "test_y = gas['thousands_barrels'][split_test:]\n",
-    "test_X = gas.drop('thousands_barrels', axis=1).iloc[split_test:, ].as_matrix()"
+    "test_X = gas.drop('thousands_barrels', axis=1).iloc[split_test:, ].to_numpy()"
    ]
   },
   {

--- a/introduction_to_applying_machine_learning/linear_time_series_forecast/linear_time_series_forecast.ipynb
+++ b/introduction_to_applying_machine_learning/linear_time_series_forecast/linear_time_series_forecast.ipynb
@@ -435,7 +435,7 @@
     "gas['thousands_barrels_lag52'] = gas['thousands_barrels'].shift(52)\n",
     "gas['thousands_barrels_lag104'] = gas['thousands_barrels'].shift(104)\n",
     "gas['thousands_barrels_naive_forecast'] = gas['thousands_barrels_lag52'] ** 2 / gas['thousands_barrels_lag104']\n",
-    "naive = gas[split_test:]['thousands_barrels_naive_forecast'].as_matrix()"
+    "naive = gas[split_test:]['thousands_barrels_naive_forecast'].to_numpy()"
    ]
   },
   {


### PR DESCRIPTION
*Description of changes:*

There was the following error AttributeError: 'DataFrame' object has no attribute 'as_matrix'
The 'as_matrix' method is deprecated since pandas version 0.23.0. Reportedly, a new method 'to_numpy' should be used now in the spirit of better consistency throughout the API.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
