### PR TITLE
Integer cannot be added to date

### DIFF
--- a/introduction_to_amazon_algorithms/deepar_synthetic/deepar_synthetic.ipynb
+++ b/introduction_to_amazon_algorithms/deepar_synthetic/deepar_synthetic.ipynb
@@ -480,7 +480,7 @@
     "        \n",
     "        Return value: list of `pandas.DataFrame` objects, each containing the predictions\n",
     "        \"\"\"\n",
-    "        prediction_times = [x.index[-1]+1 for x in ts]\n",
+    "        prediction_times = [x.index[-1]+pd.Timedelta(1, unit=freq) for x in ts]\n",
     "        req = self.__encode_request(ts, cat, encoding, num_samples, quantiles)\n",
     "        res = super(DeepARPredictor, self).predict(req)\n",
     "        return self.__decode_response(res, prediction_times, encoding)\n",


### PR DESCRIPTION
We have to add the units in which we are adding the value to date index. pandas.Timedelta(1, unit='H') (freq = 'H') declared earlier will help us here.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
