### PR TITLE
replaced numpy .as_matrix() method with .to_numpy()

### DIFF
--- a/advanced_functionality/data_distribution_types/data_distribution_types.ipynb
+++ b/advanced_functionality/data_distribution_types/data_distribution_types.ipynb
@@ -226,7 +226,7 @@
     "def prepare_gdelt(bucket, prefix, file_prefix, events=None, random_state=1729):\n",
     "    df = get_gdelt(file_prefix + '.csv')\n",
     "    model_data = transform_gdelt(df, events)\n",
-    "    train_data, validation_data = np.split(model_data.sample(frac=1, random_state=random_state).as_matrix(), \n",
+    "    train_data, validation_data = np.split(model_data.sample(frac=1, random_state=random_state).to_numpy(), \n",
     "                                           [int(0.9 * len(model_data))])\n",
     "    write_to_s3(bucket, prefix, 'train', file_prefix, train_data[:, 1:], train_data[:, 0])\n",
     "    write_to_s3(bucket, prefix, 'validation', file_prefix, validation_data[:, 1:], validation_data[:, 0])"
@@ -665,7 +665,7 @@
    },
    "outputs": [],
    "source": [
-    "test_data = transform_gdelt(get_gdelt('1984.csv'), events).as_matrix()\n",
+    "test_data = transform_gdelt(get_gdelt('1984.csv'), events).to_numpy()\n",
     "test_X = test_data[:, 1:]\n",
     "test_y = test_data[:, 0]"
    ]


### PR DESCRIPTION
*Issue:*
Notebook breaks when functions `prepare_gdelt(**args)` and `transform_gdelt (**args)` use Pandas .`as_matrix()` built-in method.

The `pandas.DataFrame.as_matrix()` has been deprecated since version 0.23.0. [Pandas API Docs](https://pandas.pydata.org/pandas-docs/version/0.25.1/reference/api/pandas.DataFrame.as_matrix.html#pandas-dataframe-as-matrix) suggests using `pandas.DataFrame.to_numpy()` instead.

*Description of changes:*
Replaced deprecated `pandas.DataFrame.as_matrix()` with `pandas.DataFrame.to_numpy()`

