### PR TITLE
Update erroring cells due to deprecated Python code

### DIFF
--- a/introduction_to_amazon_algorithms/deepar_electricity/DeepAR-Electricity.ipynb
+++ b/introduction_to_amazon_algorithms/deepar_electricity/DeepAR-Electricity.ipynb
@@ -27,6 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from __future__ import print_function\n",
     "%matplotlib inline\n",
     "\n",
     "import sys\n",
@@ -45,8 +46,8 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
+    "from datetime import timedelta\n",
     "\n",
-    "from __future__ import print_function\n",
     "from ipywidgets import interact, interactive, fixed, interact_manual\n",
     "import ipywidgets as widgets\n",
     "from ipywidgets import IntSlider, FloatSlider, Checkbox"
@@ -274,7 +275,7 @@
     "training_data = [\n",
     "    {\n",
     "        \"start\": str(start_dataset),\n",
-    "        \"target\": ts[start_dataset:end_training - 1].tolist()  # We use -1, because pandas indexing includes the upper bound \n",
+    "        \"target\": ts[start_dataset:end_training - timedelta(days=1)].tolist()  # We use -1, because pandas indexing includes the upper bound \n",
     "    }\n",
     "    for ts in timeseries\n",
     "]\n",
@@ -300,7 +301,7 @@
     "test_data = [\n",
     "    {\n",
     "        \"start\": str(start_dataset),\n",
-    "        \"target\": ts[start_dataset:end_training + k * prediction_length].tolist()\n",
+    "        \"target\": ts[start_dataset:end_training + timedelta(days=k * prediction_length)].tolist()\n",
     "    }\n",
     "    for k in range(1, num_test_windows + 1) \n",
     "    for ts in timeseries\n",
@@ -1111,9 +1112,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_mxnet_p36",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_mxnet_p36"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1125,7 +1126,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.6"
   },
   "notice": "Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.  Licensed under the Apache License, Version 2.0 (the \"License\"). You may not use this file except in compliance with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/ or in the \"license\" file accompanying this file. This file is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
  },


### PR DESCRIPTION
*Description of changes:*

Some code cells weren't running due to deprecations in Python. Specifically two:

1. `from __future__ imports` have to be at the top of your imports now
2. You cannot subtract an integer from a datetime object. You must use `timedelta` from the `datetime` library.

I fixed these cells.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
