### PR TITLE
Joblib deprecated

### DIFF
--- a/sagemaker-python-sdk/scikit_learn_randomforest/Sklearn_on_SageMaker_end2end.ipynb
+++ b/sagemaker-python-sdk/scikit_learn_randomforest/Sklearn_on_SageMaker_end2end.ipynb
@@ -149,7 +149,7 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "from sklearn.ensemble import RandomForestRegressor\n",
-    "from sklearn.externals import joblib\n",
+    "import joblib\n",
     "\n",
     "\n",
     "\n",


### PR DESCRIPTION
Hello,
Joblib is removed in the new version of SKLearn due to which from sklearn.externals import joblib does not work, import joblib works. Local execution fails but in EC2 it executes well.

Thanks

*Issue #, from sklearn.externals import joblib has been removed. import  joblib works. 

*Description of changes:* Although local execution fails but in EC2 of ML, execution succeeds.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
