### PR TITLE
fixed_instance_type_limit

### DIFF
--- a/sagemaker-python-sdk/chainer_cifar10/chainermn_distributed_cifar10.ipynb
+++ b/sagemaker-python-sdk/chainer_cifar10/chainermn_distributed_cifar10.ipynb
@@ -248,7 +248,7 @@
     "                            sagemaker_session=sagemaker_session,\n",
     "                            use_mpi=True,\n",
     "                            train_instance_count=2,\n",
-    "                            train_instance_type='ml.p2.xlarge',\n",
+    "                            train_instance_type='ml.p3.2xlarge',\n",
     "                            hyperparameters={'epochs': 30, 'batch-size': 256})\n",
     "\n",
     "chainer_estimator.fit({'train': train_input, 'test': test_input})"


### PR DESCRIPTION
*Issue #, if available:*
Notebook doesn't run, re: default quota is exceeded by using `instance_type=ml.p2.xlarge `. 

*Description of changes:*
Changed instance type from ml.p2.xlarge to ml.p3.2xlarge. Re: default quota exceeded. ml.p2.xlarge has a limit of 1 instance, ml.p3.2xlarge has a limit of 2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
