### PR TITLE
changed instance type so notebook can run for distributed training

### DIFF
--- a/sagemaker-python-sdk/keras_script_mode_pipe_mode_horovod/tensorflow_keras_CIFAR10.ipynb
+++ b/sagemaker-python-sdk/keras_script_mode_pipe_mode_horovod/tensorflow_keras_CIFAR10.ipynb
@@ -436,7 +436,7 @@
     "                            framework_version='1.15.2',\n",
     "                            py_version='py3',\n",
     "                            train_instance_count=2,\n",
-    "                            train_instance_type='ml.p2.xlarge',\n",
+    "                            train_instance_type='ml.p3.2xlarge',\n",
     "                            base_job_name='cifar10-tf-dist',\n",
     "                            tags=tags)"
    ]


### PR DESCRIPTION
*Issue #, if available:*
Notebook breaks when setting `train_instance_count `to 2 run, re: default quota is exceeded by using `instance_type=ml.p2.xlarge` 

*Description of changes:*
Changed instance type from ml.p2.xlarge to ml.p3.2xlarge. Re: default quota exceeded. ml.p2.xlarge has a limit of 1 instance, ml.p3.2xlarge has a limit of 2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
