### PR TITLE
fixed instance type

### DIFF
--- a/sagemaker-python-sdk/tensorflow_script_mode_training_and_serving/tensorflow_script_mode_training_and_serving.ipynb
+++ b/sagemaker-python-sdk/tensorflow_script_mode_training_and_serving/tensorflow_script_mode_training_and_serving.ipynb
@@ -113,7 +113,7 @@
     "mnist_estimator = TensorFlow(entry_point='mnist.py',\n",
     "                             role=role,\n",
     "                             train_instance_count=2,\n",
-    "                             train_instance_type='ml.p2.xlarge',\n",
+    "                             train_instance_type='ml.p3.2xlarge',\n",
     "                             framework_version='1.15.2',\n",
     "                             py_version='py3',\n",
     "                             distributions={'parameter_server': {'enabled': True}})"
@@ -137,7 +137,7 @@
     "mnist_estimator2 = TensorFlow(entry_point='mnist-2.py',\n",
     "                             role=role,\n",
     "                             train_instance_count=2,\n",
-    "                             train_instance_type='ml.p2.xlarge',\n",
+    "                             train_instance_type='ml.p3.2xlarge',\n",
     "                             framework_version='2.1.0',\n",
     "                             py_version='py3',\n",
     "                             distributions={'parameter_server': {'enabled': True}})"


### PR DESCRIPTION
*Issue #, if available:*
Notebook doesn't run, re: default quota is exceeded by using `instance_type=ml.p2.xlarge` .

*Description of changes:*
Changed instance type from `ml.p2.xlarge` to `ml.p3.2xlarge`. Re: default quota exceeded. `ml.p2.xlarge` has a limit of 1 instance, `ml.p3.2xlarge` has a limit of 2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
