### PR TITLE
fix input shape for prediction in scikit_bring_your_own.ipynb

### DIFF
--- a/advanced_functionality/scikit_bring_your_own/scikit_bring_your_own.ipynb
+++ b/advanced_functionality/scikit_bring_your_own/scikit_bring_your_own.ipynb
@@ -485,8 +485,7 @@
     "b = [40+i for i in range(10)]\n",
     "indices = [i+j for i,j in itertools.product(a,b)]\n",
     "\n",
-    "test_data = shape.iloc[indices[:-1]]\n",
-    "test_data = test_data.drop(test_data.columns[[0]], axis=1)"
+    "test_data = shape.iloc[indices[:-1]]\n"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*
Fixes #1360

For https://github.com/awslabs/amazon-sagemaker-examples/blob/master/advanced_functionality/scikit_bring_your_own/scikit_bring_your_own.ipynb

*Description of changes:*
The input shape was incorrect.
This rolls back part of the change in https://github.com/awslabs/amazon-sagemaker-examples/pull/826

In an earlier cell when exploring the data, the columns are already cut down to 4, so this extra step cuts it to 3 and this doesn't match the model's shape.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
