### PR TITLE
Use default bucket if not specified by the user

### DIFF
--- a/introduction_to_amazon_algorithms/random_cut_forest/random_cut_forest.ipynb
+++ b/introduction_to_amazon_algorithms/random_cut_forest/random_cut_forest.ipynb
@@ -82,7 +82,7 @@
     "import sys\n",
     "\n",
     "\n",
-    "bucket = ''   # <--- specify a bucket you have access to\n",
+    "bucket = 'sagemaker.Session().default_bucket()'   # Feel free to change to another bucket you have access to\n",
     "prefix = 'sagemaker/rcf-benchmarks'\n",
     "execution_role = sagemaker.get_execution_role()\n",
     "\n",


### PR DESCRIPTION
*Description of changes:*
Modified to use a default bucket. User can update the field with his/her own bucket which they have access to.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
