### PR TITLE
Wait until dataframe loads some data

### DIFF
--- a/sagemaker-python-sdk/scikit_learn_randomforest/Sklearn_on_SageMaker_end2end.ipynb
+++ b/sagemaker-python-sdk/scikit_learn_randomforest/Sklearn_on_SageMaker_end2end.ipynb
@@ -36,6 +36,7 @@
    "outputs": [],
    "source": [
     "import datetime\n",
+    "import time\n",
     "import tarfile\n",
     "\n",
     "import boto3\n",
@@ -448,6 +449,9 @@
    "source": [
     "# get tuner results in a df\n",
     "results = Optimizer.analytics().dataframe()\n",
+    "while results.empty:\n",
+    "    time.sleep(1)\n",
+    "    results = Optimizer.analytics().dataframe()\n",
     "results.head()"
    ]
   },


### PR DESCRIPTION
https://github.com/awslabs/amazon-sagemaker-examples/issues/1350
*Description of changes:*
Currently, the tuning job makes an asynchronous training call so the dataframe would not load any data if the cell
```
results = Optimizer.analytics().dataframe()
results.head()
```
is executed right away. Added logic to wait until the dataframe has some data to display. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
