### PR TITLE
changed training instance count from 2 to 1 in studio TensorFlow mnist notebook

### DIFF
--- a/aws_sagemaker_studio/frameworks/tensorflow_mnist/tensorflow_mnist.ipynb
+++ b/aws_sagemaker_studio/frameworks/tensorflow_mnist/tensorflow_mnist.ipynb
@@ -137,7 +137,7 @@
     "\n",
     "estimator = TensorFlow(entry_point=training_script,\n",
     "                       role=role,\n",
-    "                       train_instance_count=2,\n",
+    "                       train_instance_count=1,\n",
     "                       train_instance_type='ml.p2.xlarge',\n",
     "                       framework_version=tf_version,\n",
     "                       py_version='py3',\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In aws_sagemaker_studio/frameworks/tensorflow_mnist/tensorflow_mnist.ipynb, changed the training instance count from 2 to 1. The default limit for the instance type (p2 xlarge) is 1, so the notebook fails for a typical user without a limit increase. Works with the change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
