### PR TITLE
Updated parquet-to-recordio-protobuf notebook to use default bucket

### DIFF
--- a/advanced_functionality/parquet_to_recordio_protobuf/parquet_to_recordio_protobuf.ipynb
+++ b/advanced_functionality/parquet_to_recordio_protobuf/parquet_to_recordio_protobuf.ipynb
@@ -41,11 +41,14 @@
     "import pandas as pd\n",
     "import numpy as np\n",
     "import time\n",
+    "import sagemaker\n",
     "from sagemaker import get_execution_role\n",
     "\n",
     "role = get_execution_role()\n",
     "\n",
-    "bucket = '<S3 bucket>'\n",
+    "sagemaker_session = sagemaker.Session()\n",
+    "\n",
+    "bucket = sagemaker_session.default_bucket()\n",
     "prefix = 'sagemaker/DEMO-parquet'"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 Updated the example notebook /advanced_functionality/parquet_to_recordio_protobuf/parquet-to-recordio-protobuf notebook to use a default bucket instead of user-supplied bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
