### PR TITLE
Minor: fix typo in introduction_to_applying_machine_learning/US-censu…

### DIFF
--- a/introduction_to_applying_machine_learning/US-census_population_segmentation_PCA_Kmeans/sagemaker-countycensusclustering.ipynb
+++ b/introduction_to_applying_machine_learning/US-census_population_segmentation_PCA_Kmeans/sagemaker-countycensusclustering.ipynb
@@ -409,7 +409,7 @@
    "outputs": [],
    "source": [
    "sess = sagemaker.Session()\n",
-   "bucket=sess.default_bucket()""
+   "bucket=sess.default_bucket()"
    ]
   },
   {


### PR DESCRIPTION
…s_population_segmentation_PCA_Kmeans/sagemaker-countycensusclustering.ipynb

* Remove extra `"` character to fix the notebook.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
