### PR TITLE
Revert "Update XBoost Notebooks To Use Sagemaker SDK V2"

### DIFF
--- a/sagemaker-debugger/xgboost_builtin_rules/xgboost-regression-debugger-rules.ipynb
+++ b/sagemaker-debugger/xgboost_builtin_rules/xgboost-regression-debugger-rules.ipynb
@@ -56,7 +56,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Amazon SageMaker Debugger is available in Amazon SageMaker XGBoost container version 0.90-2 or later. If you want to use XGBoost with Amazon SageMaker Debugger, you have to specify `repo_version='0.90-2'` in the `retrieve` function."
+    "Amazon SageMaker Debugger is available in Amazon SageMaker XGBoost container version 0.90-2 or later. If you want to use XGBoost with Amazon SageMaker Debugger, you have to specify `repo_version='0.90-2'` in the `get_image_uri` function."
    ]
   },
   {
@@ -65,12 +65,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.image_uris import retrieve\n",
+    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
     "\n",
     "# Below changes the Region to be one where this notebook is running\n",
     "region = boto3.Session().region_name\n",
     "\n",
-    "container = retrieve(region=region, framework=\"xgboost\", version=\"0.90-2\")"
+    "container = get_image_uri(region, \"xgboost\", repo_version=\"0.90-2\")"
    ]
   },
   {
@@ -237,11 +237,11 @@
     "algorithm_mode_default_estimator = Estimator(\n",
     "    role=role,\n",
     "    base_job_name=base_job_name,\n",
-    "    instance_count=1,\n",
-    "    instance_type='ml.m5.xlarge',\n",
-    "    image_uri=container,\n",
+    "    train_instance_count=1,\n",
+    "    train_instance_type='ml.m5.xlarge',\n",
+    "    image_name=container,\n",
     "    hyperparameters=hyperparameters,\n",
-    "    max_run=1800,\n",
+    "    train_max_run=1800,\n",
     "\n",
     "    debugger_hook_config=DebuggerHookConfig(\n",
     "        s3_output_path=bucket_path,  # Required\n",
@@ -292,10 +292,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.inputs import TrainingInput\n",
+    "from sagemaker.session import s3_input\n",
     "\n",
-    "train_s3_input = TrainingInput(\"s3://{}/{}/{}\".format(bucket, prefix, \"train\"), content_type=\"libsvm\")\n",
-    "validation_s3_input = TrainingInput( \"s3://{}/{}/{}\".format(bucket, prefix, \"validation\"), content_type=\"libsvm\")\n",
+    "train_s3_input = s3_input(\"s3://{}/{}/{}\".format(bucket, prefix, \"train\"), content_type=\"libsvm\")\n",
+    "validation_s3_input = s3_input( \"s3://{}/{}/{}\".format(bucket, prefix, \"validation\"), content_type=\"libsvm\")\n",
     "algorithm_mode_default_estimator.fit(\n",
     "    {\"train\": train_s3_input, \"validation\": validation_s3_input},\n",
     "    # This is a fire and forget event. By setting wait=False, you just submit the job to run in the background.\n",
@@ -640,5 +640,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/sagemaker-debugger/xgboost_census_explanations/xgboost-census-debugger-rules.ipynb
+++ b/sagemaker-debugger/xgboost_census_explanations/xgboost-census-debugger-rules.ipynb
@@ -130,7 +130,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Amazon SageMaker Debugger is available in Amazon SageMaker XGBoost container version 0.90-2 or later. If you want to use XGBoost with Amazon SageMaker Debugger, you have to specify `repo_version='0.90-2'` in the `retrieve` function."
+    "Amazon SageMaker Debugger is available in Amazon SageMaker XGBoost container version 0.90-2 or later. If you want to use XGBoost with Amazon SageMaker Debugger, you have to specify `repo_version='0.90-2'` in the `get_image_uri` function."
    ]
   },
   {
@@ -139,8 +139,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.image_uris import retrieve\n",
-    "container = retrieve(region=region, framework=\"xgboost\", version=\"0.90-2\")"
+    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
+    "container = get_image_uri(region, \"xgboost\", repo_version=\"0.90-2\")"
    ]
   },
   {
@@ -261,8 +261,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.amazon.amazon_estimator import retrieve\n",
-    "container = retrieve(region=region, framework=\"xgboost\", version=\"0.90-2\")"
+    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
+    "container = get_image_uri(region, \"xgboost\", repo_version=\"0.90-2\")"
    ]
   },
   {
@@ -377,11 +377,11 @@
     "xgboost_estimator = Estimator(\n",
     "    role=role,\n",
     "    base_job_name=base_job_name,\n",
-    "    instance_count=1,\n",
-    "    instance_type='ml.m5.4xlarge',\n",
-    "    image_uri=container,\n",
+    "    train_instance_count=1,\n",
+    "    train_instance_type='ml.m5.4xlarge',\n",
+    "    image_name=container,\n",
     "    hyperparameters=hyperparameters,\n",
-    "    max_run=1800,\n",
+    "    train_max_run=1800,\n",
     "\n",
     "    debugger_hook_config=DebuggerHookConfig(\n",
     "        s3_output_path=bucket_path,  # Required\n",
@@ -438,11 +438,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.session import TrainingInput\n",
+    "from sagemaker.session import s3_input\n",
     "\n",
-    "train_input = TrainingInput(\"s3://{}/{}/{}\".format(bucket,\n",
+    "train_input = s3_input(\"s3://{}/{}/{}\".format(bucket,\n",
     "                                              prefix, \"data/train.csv\"), content_type=\"csv\")\n",
-    "validation_input = TrainingInput(\n",
+    "validation_input = s3_input(\n",
     "    \"s3://{}/{}/{}\".format(bucket, prefix, \"data/validation.csv\"), content_type=\"csv\")\n",
     "xgboost_estimator.fit(\n",
     "    {\"train\": train_input, \"validation\": validation_input},\n",
@@ -740,7 +740,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "shap.summary_plot(shap_no_base, X_train)"
@@ -929,5 +931,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/sagemaker-debugger/xgboost_realtime_analysis/xgboost-realtime-analysis.ipynb
+++ b/sagemaker-debugger/xgboost_realtime_analysis/xgboost-realtime-analysis.ipynb
@@ -76,11 +76,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.amazon.amazon_estimator import retrieve\n",
+    "from sagemaker.amazon.amazon_estimator import get_image_uri\n",
     "\n",
     "# Below changes the region to be one where this notebook is running\n",
     "region = boto3.Session().region_name\n",
-    "container = retrieve(region=region, framework=\"xgboost\", version=\"0.90-2\")"
+    "container = get_image_uri(region, \"xgboost\", repo_version=\"0.90-2\")"
    ]
   },
   {
@@ -207,11 +207,11 @@
     "xgboost_algorithm_mode_estimator = Estimator(\n",
     "    role=role,\n",
     "    base_job_name=base_job_name,\n",
-    "    instance_count=1,\n",
-    "    instance_type='ml.m5.xlarge',\n",
-    "    image_uri=container,\n",
+    "    train_instance_count=1,\n",
+    "    train_instance_type='ml.m5.xlarge',\n",
+    "    image_name=container,\n",
     "    hyperparameters=hyperparameters,\n",
-    "    max_run=1800,\n",
+    "    train_max_run=1800,\n",
     "\n",
     "    debugger_hook_config = DebuggerHookConfig(\n",
     "        s3_output_path=bucket_path,  # Required\n",
@@ -256,10 +256,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sagemaker.session import TrainingInput\n",
+    "from sagemaker.session import s3_input\n",
     "\n",
-    "train_s3_input = TrainingInput(\"s3://{}/{}/{}\".format(bucket, prefix, \"train\"), content_type=\"libsvm\")\n",
-    "validation_s3_input = TrainingInput(\"s3://{}/{}/{}\".format(bucket, prefix, \"validation\"), content_type=\"libsvm\")\n",
+    "train_s3_input = s3_input(\"s3://{}/{}/{}\".format(bucket, prefix, \"train\"), content_type=\"libsvm\")\n",
+    "validation_s3_input = s3_input(\"s3://{}/{}/{}\".format(bucket, prefix, \"validation\"), content_type=\"libsvm\")\n",
     "\n",
     "# This is a fire and forget event. By setting wait=False, you just submit the job to run in the background.\n",
     "# Amazon SageMaker will start one training job and release control to next cells in the notebook.\n",


### PR DESCRIPTION
Reverts awslabs/amazon-sagemaker-examples#1495

This update caused errors without returning what is the source of error. 
The current NI/Studio kernels use SageMaker pySDK v1 by default, so the v2 changes made in this notebooks brakes.
This revert is to pin the notebook samples to use SageMaker pySDK v1 and avoid any errors due to the version incompatibility.
Will update the v2 version notebooks with coordinated plans for kernel updates with pySDK v2.