### PR TITLE
fix: remove `pip install sagemaker --upgrade` command

### DIFF
--- a/aws_sagemaker_studio/sagemaker_experiments/track-airflow-workflow/track-an-airflow-workflow.ipynb
+++ b/aws_sagemaker_studio/sagemaker_experiments/track-airflow-workflow/track-an-airflow-workflow.ipynb
@@ -57,7 +57,6 @@
     "!{sys.executable} -m pip install apache-airflow\n",
     "!{sys.executable} -m pip install sagemaker-experiments\n",
     "!{sys.executable} -m pip install matplotlib\n",
-    "!{sys.executable} -m pip install sagemaker --upgrade"
    ]
   },
   {

--- a/sagemaker-experiments/track-an-airflow-workflow/track-an-airflow-workflow.ipynb
+++ b/sagemaker-experiments/track-an-airflow-workflow/track-an-airflow-workflow.ipynb
@@ -57,7 +57,6 @@
     "!{sys.executable} -m pip install apache-airflow\n",
     "!{sys.executable} -m pip install sagemaker-experiments\n",
     "!{sys.executable} -m pip install matplotlib\n",
-    "!{sys.executable} -m pip install sagemaker --upgrade"
    ]
   },
   {


### PR DESCRIPTION
*Description of changes:*
Remove commands from `track-an-airflow-workflow.ipynb` notebooks that manually upgrade the SageMaker Python SDK to v2.

*Testing done:*
Ran modified notebooks on Notebook Instance and Studio. Notebooks successfully ran end-to-end.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
